### PR TITLE
Escape '+' in escape_string()

### DIFF
--- a/libraries/provider_append_if_no_line.rb
+++ b/libraries/provider_append_if_no_line.rb
@@ -26,7 +26,7 @@ class Chef
       end
 
       def escape_string(string)
-        pattern = /(\'|\"|\.|\*|\/|\-|\\|\(|\))/
+        pattern = /(\+|\'|\"|\.|\*|\/|\-|\\|\(|\))/
         string.gsub(pattern){|match|"\\" + match}
       end
       


### PR DESCRIPTION
'+' needs to be escaped. Without it, my line with '+' in it was being appended every Chef run, infinitely growing the file.
