### PR TITLE
Escape '+' in escape_string() here too...

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -19,6 +19,6 @@
 #    
 
 def escape_string(string)
-  pattern = /(\'|\"|\.|\*|\/|\-|\\|\(|\))/
+  pattern = /(\+|\'|\"|\.|\*|\/|\-|\\|\(|\))/
   string.gsub(pattern){|match|"\\" + match}
 end


### PR DESCRIPTION
Unsure why this is defined here and also in some of the providers, but just updating this one here too in case it is intentionally still here.
