### PR TITLE
Makes replace_or_add function properly

### DIFF
--- a/libraries/provider_replace_or_add.rb
+++ b/libraries/provider_replace_or_add.rb
@@ -47,7 +47,7 @@ class Chef
             f.lines.each do |line|
               if line =~ regex then
                 found = true
-                unless line == new_resource.line
+                unless line == new_resource.line << "\n"
                   line = new_resource.line
                   modified = true
                 end
@@ -55,8 +55,9 @@ class Chef
               temp_file.puts line
             end
 
-            if (found && !modified) then
-              f.puts new_resource.line
+            if (!found && !modified) then # "add"!
+              temp_file.puts new_resource.line
+              modified = true
             end
 
             f.close
@@ -91,4 +92,3 @@ class Chef
     end
   end
 end
-


### PR DESCRIPTION
When the regex matches a line in the target file, we now properly
compare it against a _newline-terminated_ version of
new_resource.line to determine if the line is correct or needs
to be updated.

When the regex is not matched, and so the file is not modified,
we are in "add" mode and spit out new_resource.line to the
open temp file. This was mistakenly spitting out to the original
file (and silently failing as it was only open for r+ ... but it
was the wrong place to write anyway - remnant from previous code)
