### PR TITLE
Use explicit path method for compatitibility with older ruby

### DIFF
--- a/libraries/provider_replace_or_add.rb
+++ b/libraries/provider_replace_or_add.rb
@@ -64,7 +64,7 @@ class Chef
 
             if modified then
               temp_file.rewind
-              FileUtils.copy_file(temp_file,new_resource.path)
+              FileUtils.copy_file(temp_file.path,new_resource.path)
               FileUtils.chown(file_owner,file_group,new_resource.path)
               FileUtils.chmod(file_mode,new_resource.path)              
               new_resource.updated_by_last_action(true)


### PR DESCRIPTION
It appears that fileutils in older ruby does not accept a 'File' object as a parameter and copy fails without using the ".path" method for temp file

Older Ruby:

```
    # ruby -v
    ruby 1.8.7 (2011-06-30 patchlevel 352) [x86_64-linux]
    # irb
    irb(main):001:0> require 'tempfile'
    => true
    irb(main):002:0> f = Tempfile.new("t1")
    => #<File:/tmp/t120130811-20254-3wbr44-0>
    irb(main):003:0> FileUtils.copy(f, "/tmp/t2")
    NoMethodError: undefined method `to_str' for #<File:/tmp/t120130811-20254-3wbr44-0>
    from /usr/lib/ruby/1.8/delegate.rb:269:in `method_missing'
    from /usr/lib/ruby/1.8/fileutils.rb:1414:in `fu_each_src_dest0'
    from /usr/lib/ruby/1.8/fileutils.rb:1400:in `fu_each_src_dest'
    from /usr/lib/ruby/1.8/fileutils.rb:382:in `copy'
    from (irb):3
    from /usr/lib/ruby/1.8/fileutils.rb:1133
```

Newer Ruby:

```
    # ruby -v
    ruby 1.9.3p327 (2012-11-10 revision 37606) [x86_64-darwin12.3.0]
    # irb
    irb(main):001:0> require 'tempfile'
    => true
    irb(main):002:0> f = Tempfile.new("t1")
    => #<File:/var/folders/pl/r2rzc64d0lx80zrh74ft54bm0000gn/T/t120130811-42691-ool754>
    irb(main):003:0> FileUtils.copy(f, "/tmp/t2")
    => nil
```
