### PR TITLE
fixed 'to_str' method not found exception in 1.8.7

### DIFF
--- a/libraries/provider_replace_or_add.rb
+++ b/libraries/provider_replace_or_add.rb
@@ -64,7 +64,7 @@ class Chef
 
             if modified then
               temp_file.rewind
-              FileUtils.copy_file(temp_file,new_resource.path)
+              FileUtils.copy_file(temp_file.path,new_resource.path)
               FileUtils.chown(file_owner,file_group,new_resource.path)
               FileUtils.chmod(file_mode,new_resource.path)              
               new_resource.updated_by_last_action(true)


### PR DESCRIPTION
This work both 1.8.7 and 1.9.3.
