### PR TITLE
Fixes broken "Add" functionality of replace_or_add

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ the resoures.
       line "Why hello there, you beautiful person, you."
     end
 
+    delete_lines "remove hash-comments from /some/file" do
+      path "/some/file"
+      pattern "^#.*"
+    end
+
 # Notes
 So far, the only resource implemented are 
 
-    append_if_no_line.
+    append_if_no_line
     replace_or_add
+    delete_lines
 
 More to follow.
 

--- a/libraries/provider_delete_lines.rb
+++ b/libraries/provider_delete_lines.rb
@@ -1,0 +1,77 @@
+#
+# Cookbook Name:: line
+# Library:: provider_delete_lines
+#
+# Author:: Sean OMeara <someara@opscode.com>
+# Author:: Jeff Blaine <jblaine@kickflop.net>
+# Copyright 2012-2013, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'fileutils'
+require 'tempfile'
+
+class Chef
+  class Provider
+    class DeleteLines < Chef::Provider
+
+      def load_current_resource
+      end
+
+      def action_edit
+        regex = /#{new_resource.pattern}/
+
+        if ::File.exists?(new_resource.path) then
+          begin
+            f = ::File.open(new_resource.path, "r+")
+
+            file_owner = f.lstat.uid
+            file_group = f.lstat.gid
+            file_mode = f.lstat.mode
+
+            temp_file = Tempfile.new('foo')
+
+            modified = false
+
+            f.lines.each do |line|
+              if line =~ regex then
+                modified = true
+              else
+                temp_file.puts line
+              end
+            end
+
+            f.close
+
+            if modified then
+              temp_file.rewind
+              FileUtils.copy_file(temp_file.path,new_resource.path)
+              FileUtils.chown(file_owner,file_group,new_resource.path)
+              FileUtils.chmod(file_mode,new_resource.path)
+              new_resource.updated_by_last_action(true)
+            end
+
+          ensure
+            temp_file.close
+            temp_file.unlink
+          end
+        end # ::File.exists
+      end # def action_edit
+
+      def action_nothing
+      end
+
+    end
+  end
+end

--- a/libraries/provider_replace_or_add.rb
+++ b/libraries/provider_replace_or_add.rb
@@ -55,7 +55,7 @@ class Chef
               temp_file.puts line
             end
 
-            if (!found && modified) then # "add"!
+            if (!found) then # "add"!
               temp_file.puts new_resource.line
               modified = true
             end

--- a/libraries/resource_delete_lines.rb
+++ b/libraries/resource_delete_lines.rb
@@ -1,0 +1,50 @@
+# Cookbook Name:: line
+# Library:: resource_delete_lines
+#
+# Author:: Sean OMeara <someara@opscode.com>
+# Author:: Jeff Blaine <jblaine@kickflop.net>
+# Copyright 2012-2013, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  class Resource
+    class DeleteLines < Chef::Resource
+
+      def initialize(name, run_context=nil)
+        super
+        @resource_name = :delete_lines
+        @action = :edit
+        @allowed_actions.push(:edit,:nothing)
+      end
+
+      def path(arg=nil)
+        set_or_return(
+          :path,
+          arg,
+          :kind_of => String
+          )
+      end
+
+      def pattern(arg=nil)
+        set_or_return(
+          :line,
+          arg,
+          :kind_of => String
+          )
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
As is, 0.5.1 (and likely earlier) have a bug where the "or add" functionality of replace_or_add does not work at all.

This patch corrects that bug. I think I introduced it during cleanup of this file a few months back.
