### PR TITLE
Add $ and ^ to list of characters to escape in regex.

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -19,6 +19,6 @@
 #    
 
 def escape_string(string)
-  pattern = /(\+|\'|\"|\.|\*|\/|\-|\\|\(|\)|\{|\})/
+  pattern = /(\+|\'|\"|\.|\*|\/|\-|\\|\(|\)|\{|\}|\^|\$)/
   string.gsub(pattern){|match|"\\" + match}
 end


### PR DESCRIPTION
The escape_string method did not include ^ and $ in the list of
characters to escape. This caused append_if_no_line to possibly add
lines with a dollar sign in them many times even after they have been
added.

Fix issue #14.
