### PR TITLE
Multiple matches cause unnecessary newlines in replace_or_add

### DIFF
--- a/libraries/provider_replace_or_add.rb
+++ b/libraries/provider_replace_or_add.rb
@@ -47,7 +47,7 @@ class Chef
             f.lines.each do |line|
               if line =~ regex then
                 found = true
-                unless line == new_resource.line << "\n"
+                unless line == new_resource.line + "\n"
                   line = new_resource.line
                   modified = true
                 end


### PR DESCRIPTION
If the pattern is matched by more than one line in the file, the second comparison (and all the following ones) would always fail since `new_resource.line` already ends with `\n` at that point.  Therefore, these matches line would be replaced with the same line _plues another newline_.

This change should avoid that :)
