### PR TITLE
Catch lines missed by strict patterns

### DIFF
--- a/libraries/provider_replace_or_add.rb
+++ b/libraries/provider_replace_or_add.rb
@@ -55,8 +55,6 @@ class Chef
                 # This catches when 'new_resource.pattern' matches line on
                 # first pass but fails on second pass appending the line
                 # to the bottom of temp_file.
-                Chef::Log.info("WARN: Consider adjusting the pattern attribute in replace_or_add resource.")
-                Chef::Log.info("WARN: The pattern did not match but the line was found.")
                 found = true
               end
               temp_file.puts line

--- a/libraries/provider_replace_or_add.rb
+++ b/libraries/provider_replace_or_add.rb
@@ -51,6 +51,13 @@ class Chef
                   line = new_resource.line
                   modified = true
                 end
+              elsif line == new_resource.line then
+                # This catches when 'new_resource.pattern' matches line on
+                # first pass but fails on second pass appending the line
+                # to the bottom of temp_file.
+                Chef::Log.info("WARN: Consider adjusting the pattern attribute in replace_or_add resource.")
+                Chef::Log.info("WARN: The pattern did not match but the line was found.")
+                found = true
               end
               temp_file.puts line
             end


### PR DESCRIPTION
There are times where a pattern will match on first run and replace the line with the given value.  On second run the line will not match the pattern and the line will then be appended to the bottom of the file.  This is bad, especially if the file depends on formatting like XML.
