### PR TITLE
Add rspec tests for the replace_or_add provider.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
-site 'https://supermarket.chef.io'
+source 'https://supermarket.chef.io'
 
 metadata
+cookbook 'line_tests', path: 'spec/fixtures/cookbooks/line_tests'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 line Cookbook CHANGELOG
 ========================
 
+
+--------------------
+- Add rspec tests for the replace_or_add provider. The existing chefspec tests don't step into the provider code and so don't check the provider functionality.
+- Change the Gemfile to reflect the need for berkshelf 3, chefspec v4.2, rspec 3 for the tests.
+- Update provider_replace_or_add to handle cases where the pattern does not match the replacement line.
+- Fix an idempotence problem where updated_by_last_action was set even though nothing was changed.
+
 v0.6.1 (2015-02-24)
 --------------------
 - Adding CHANGELOG

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 2.0'
-gem 'rspec', :group => :integration
-gem 'chefspec', '~> 3.0', :group => :integration
+gem 'berkshelf', '~> 3.0'
+gem 'rspec', '~> 3.0', :group => :integration
+gem 'chefspec', '~> 4.2', :group => :integration
 gem 'guard', :group => :integration
 gem 'test-kitchen', :group => :integration
 gem 'kitchen-vagrant', :group => :integration

--- a/libraries/provider_replace_or_add.rb
+++ b/libraries/provider_replace_or_add.rb
@@ -45,9 +45,9 @@ class Chef
             found = false
 
             f.each_line do |line|
-              if line =~ regex then
+              if line =~ regex || line.chomp == new_resource.line then
                 found = true
-                unless line == new_resource.line + "\n"
+                unless line.chomp == new_resource.line
                   line = new_resource.line
                   modified = true
                 end

--- a/spec/fixtures/cookbooks/line_tests/README.md
+++ b/spec/fixtures/cookbooks/line_tests/README.md
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Recipes to generate tests for the line command
+
+Each recipe encodes a single resource.  The tests are designed to exercise the
+provider code and the way the file routines are mocked the changes to the files
+are not passed from resource to resource.  

--- a/spec/fixtures/cookbooks/line_tests/metadata.rb
+++ b/spec/fixtures/cookbooks/line_tests/metadata.rb
@@ -1,0 +1,19 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name 'line_tests'

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_another_line_matching_pattern.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_another_line_matching_pattern.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'another_line_matching_pattern' do
+  path 'file'
+  pattern 'Add another line'
+  line 'Add another line'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_change_line_eof.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_change_line_eof.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'change_line_eof' do
+  path 'file'
+  pattern 'Last line'
+  line 'Last line changed'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_duplicate.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_duplicate.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'duplicate' do
+  path 'file'
+  pattern 'Identical line'
+  line 'Replace duplicate lines'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_line_eof.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_line_eof.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'line_eof' do
+  path 'file'
+  pattern 'Last line'
+  line 'Last line'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_line_mid_file.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_line_mid_file.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'line_mid_file' do
+  path 'file'
+  pattern 'Third line'
+  line 'Third line'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_line_present_at_end.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_line_present_at_end.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'line_present_at_end' do
+  path 'file'
+  pattern 'Does not match'
+  line 'Last line'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_line_present_in_middle.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_line_present_in_middle.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'line_present_in_middle' do
+  path 'file'
+  pattern 'Does not match'
+  line 'Penultimate'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_match_third_line.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_match_third_line.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'match_third_line' do
+  path 'file'
+  pattern '^Third line'
+  line 'Different replacement'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_middle_match.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_middle_match.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'middle_match' do
+  path 'file'
+  pattern 'data line'
+  line 'data line extended'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_missing_00.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_missing_00.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'missing_file' do
+  path 'missingfile'
+  pattern 'Does not match'
+  line 'add this line'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_missing_01.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_missing_01.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'missing_file' do
+  path 'missingfile'
+  pattern '^add this'
+  line 'add this line'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_start_of_line_match.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_start_of_line_match.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'start_of_line_match' do
+  path 'file'
+  pattern 'Data line'
+  line 'Data line longer and longer'
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_unmatched_line.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_unmatched_line.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'unmatched_line' do
+  path 'file'
+  pattern 'Does not match'
+  line 'Unmatched line'
+end

--- a/spec/replace_or_add_spec.rb
+++ b/spec/replace_or_add_spec.rb
@@ -1,0 +1,255 @@
+#
+# Cookbook Name:: line
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'rspec_helper'
+require 'stringio'
+
+describe 'replace_or_add lines in an existing file' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['replace_or_add'])
+  end
+
+  let(:testfile) do
+    'Data line
+    Alt data line extended
+    Third line
+    Identical line
+    Identical line
+    Penultimate
+    Last line'.gsub!(/^\s+/, '')
+  end
+
+  let(:testfile_size) { testfile.lines.count }
+
+  before do
+    @temp_file = Tempfile.new('foo')
+    @file_content = testfile
+    file_replacement
+  end
+
+  context 'when the pattern does not match the replacement line' do
+    describe 'replacement line matches a line in the middle a file' do
+      before { chef_run.converge('line_tests::replace_or_add_line_present_in_middle') }
+      it 'does not add extra lines' do
+        expect(@file_content.scan(/^Penultimate$/).size).to eq(1)
+      end
+      it 'does not change the file size' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'is idempotent' do
+        expect(chef_run).to edit_replace_or_add('line_present_in_middle').with(updated_by_last_action?: false)
+      end
+    end
+
+    describe 'replacement line matches the final line' do
+      before { chef_run.converge('line_tests::replace_or_add_line_present_at_end') }
+      it 'does not add extra lines' do
+        expect(@file_content.scan(/^Last line$/).size).to eq(1)
+      end
+      it 'does not change the file size' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'is idempotent' do
+        expect(chef_run).to edit_replace_or_add('line_present_at_end').with(updated_by_last_action?: false)
+      end
+    end
+
+    describe 'search does not match the file' do
+      before { chef_run.converge('line_tests::replace_or_add_unmatched_line') }
+      it 'should add line contents' do
+        expect(@file_content.scan(/^Unmatched line$/).size).to eq(1)
+      end
+      it 'should add one line' do
+        expect(@file_content.lines.count).to eq(testfile_size + 1)
+      end
+      it 'should flag the resource change' do
+        expect(chef_run).to edit_replace_or_add('unmatched_line').with(updated_by_last_action?: true)
+      end
+    end
+
+    describe 'pattern matches a line' do
+      before { chef_run.converge('line_tests::replace_or_add_match_third_line') }
+      it 'should replace a line' do
+        expect(@file_content.scan(/^Different replacement$/).size).to eq(1)
+      end
+      it 'should not add lines' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'should flag the resource change' do
+        expect(chef_run).to edit_replace_or_add('match_third_line').with(updated_by_last_action?: true)
+      end
+    end
+  end
+
+  context 'when the pattern does match the replacement line' do
+    describe 'search does not match the file' do
+      before { chef_run.converge('line_tests::replace_or_add_another_line_matching_pattern') }
+      it 'should add the right line' do
+        expect(@file_content.scan(/^Add another line$/).size).to eq(1)
+      end
+      it 'should add one line' do
+        expect(@file_content.lines.count).to eq(testfile_size + 1)
+      end
+      it 'should flag the resource change' do
+        expect(chef_run).to edit_replace_or_add('another_line_matching_pattern').with(updated_by_last_action?: true)
+      end
+    end
+
+    describe 'search matches a line' do
+      before { chef_run.converge('line_tests::replace_or_add_middle_match') }
+      it 'should add the right line' do
+        expect(@file_content.scan(/^data line extended$/).size).to eq(1)
+      end
+      it 'should delete the original line' do
+        expect(@file_content).not_to match(/Alt data line extended/)
+      end
+      it 'should not add lines' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'should flag the resource change' do
+        expect(chef_run).to edit_replace_or_add('middle_match').with(updated_by_last_action?: true)
+      end
+    end
+
+    describe 'search matches when the pattern anchors the line start' do
+      before { chef_run.converge('line_tests::replace_or_add_start_of_line_match') }
+      it 'should change a line correctly' do
+        expect(@file_content.scan(/^Data line longer and longer$/).size).to eq(1)
+      end
+      it 'should not add lines' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'should flag the resource change' do
+        expect(chef_run).to edit_replace_or_add('start_of_line_match').with(updated_by_last_action?: true)
+      end
+    end
+
+    describe 'when pattern matches and the last line does not end in \n' do
+      before { chef_run.converge('line_tests::replace_or_add_change_line_eof') }
+      it 'should change the line' do
+        expect(@file_content.scan(/^Last line changed$/).size).to eq(1)
+      end
+      it 'should not add lines' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'should flag the resource change' do
+        expect(chef_run).to edit_replace_or_add('change_line_eof').with(updated_by_last_action?: true)
+      end
+    end
+
+    describe 'when line matches and the last line does not end in \n' do
+      before { chef_run.converge('line_tests::replace_or_add_line_eof') }
+      it 'should not change the line' do
+        expect(@file_content.scan(/^Last line$/).size).to eq(1)
+      end
+      it 'should not add lines' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'should be idempotent' do
+        expect(chef_run).to edit_replace_or_add('line_eof').with(updated_by_last_action?: false)
+      end
+    end
+
+    describe 'when line matchs in the middle of a file' do
+      before { chef_run.converge('line_tests::replace_or_add_line_mid_file') }
+      it 'should not change the line' do
+        expect(@file_content.scan(/^Third line$/).size).to eq(1)
+      end
+      it 'should not add lines' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'should flag the resource change' do
+        expect(chef_run).to edit_replace_or_add('line_mid_file').with(updated_by_last_action?: false)
+      end
+    end
+
+    describe 'when multiple lines match' do
+      before { chef_run.converge('line_tests::replace_or_add_duplicate') }
+      it 'should change both lines' do
+        expect(@file_content.scan(/^Replace duplicate lines$/).size).to eq(2)
+      end
+      it 'should not add lines' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'should flag the resource change' do
+        expect(chef_run).to edit_replace_or_add('duplicate').with(updated_by_last_action?: true)
+      end
+    end
+  end
+end
+
+describe 'replace_or_add lines in a missing file' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['replace_or_add'])
+  end
+
+  before(:each) do
+    @temp_file = Tempfile.new('foo')
+    @file_content = ''
+    file_replacement
+  end
+
+  context 'when the pattern does not match the replacement line' do
+    before {  chef_run.converge('line_tests::replace_or_add_missing_00') }
+    it 'should add a line' do
+      expect(@file_content.scan(/^add this line$/).size).to eq(1)
+    end
+    it 'should flag the resource change' do
+      expect(chef_run).to edit_replace_or_add('missing_file').with(updated_by_last_action?: true)
+    end
+  end
+
+  context 'when the pattern matches the replacement line' do
+    before { chef_run.converge('line_tests::replace_or_add_missing_01') }
+    it 'should add a line' do
+      expect(@file_content.scan(/^add this line$/).size).to eq(1)
+    end
+    it 'should flag the resource change' do
+      expect(chef_run).to edit_replace_or_add('missing_file').with(updated_by_last_action?: true)
+    end
+  end
+end
+
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+def file_replacement
+  allow(::File).to receive(:exists?).and_call_original
+  allow(Tempfile).to receive(:new).and_call_original
+  allow(FileUtils).to receive(:copy_file).and_call_original
+  # Specific replacements
+  allow(::File).to receive(:exists?).with('file').and_return(true)
+  fake_file = StringIO.open(@file_content)
+  fake_lstat = double
+  allow(::File).to receive(:open).with('file', 'r+').and_return(fake_file)
+  allow(fake_file).to receive(:lstat).and_return(fake_lstat)
+  allow(fake_lstat).to receive(:uid).and_return(0)
+  allow(fake_lstat).to receive(:gid).and_return(0)
+  allow(fake_lstat).to receive(:mode).and_return(775)
+  allow(fake_file).to receive(:close) { fake_file.rewind }
+  allow(Tempfile).to receive(:new).with('foo').and_return(@temp_file)
+  allow(@temp_file).to receive(:close) { @temp_file.rewind }
+  allow(@temp_file).to receive(:unlink)
+  allow(FileUtils).to receive(:copy_file).with(@temp_file.path, 'file') { @file_content = @temp_file.read }
+  allow(FileUtils).to receive(:chown)
+  allow(FileUtils).to receive(:chmod)
+  missing_file = double
+  allow(::File).to receive(:exists?).with('missingfile').and_return(false)
+  allow(::File).to receive(:open).with('missingfile', 'w').and_return(missing_file)
+  allow(missing_file).to receive(:puts) { |line| @file_content << "#{line}\n" }
+  allow(missing_file).to receive(:close)
+end
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/spec/rspec_helper.rb
+++ b/spec/rspec_helper.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook Name:: line
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+Dir.glob('libraries/*.rb') do |file|
+  require "./#{file}"
+end
+
+RSpec.configure do |config|
+  config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+  config.order = 'random'
+  config.expose_dsl_globally = true
+end

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 # Historical Note: For those coming across this cookbook, these
-# filenames were of the original author's doing (Seam O'Meara).
+# filenames were of the original author's doing (Sean O'Meara).
 # There is no special meaning behind them, so don't be confused.
 # He's just weird like the rest of us.
 


### PR DESCRIPTION
Change replace_or_add so that the replacement line does not have to
match the pattern for lines to be added only a single time.

I believe this PR includes a fix for issue #28, and fixes the problems fixed by PR #29, and fixes at least two further issues.  The current chefspec tests do not step into the provider code and I don't believe that the tests check the provider code at all.  I added chefspec tests to check particular cases where I have encountered problems with the replace_or_add resource.  I added quite a few separate recipes to test.  The way I created mock entities for testing the provider doesn't allow for passing a file from resource to resource, so each test was done with one resource/recipe.  

I changed replace_or_add to handle the case where the replacing/added line doesn't match the pattern.  The current behavior is to append the replacement line on every execution which is really nasty behavior.  My change adds the line once if it is missing (pattern and line do not match) and will changes lines if the pattern matches.   

For what it's worth, I have run this version of the code on real servers and have serverspec tests set up to verify the function. 
