### PR TITLE
The last set of rubocop fixes broke the rspec tests.  

### DIFF
--- a/libraries/provider_replace_or_add.rb
+++ b/libraries/provider_replace_or_add.rb
@@ -50,11 +50,6 @@ class Chef
                   line = new_resource.line
                   modified = true
                 end
-              elsif line == new_resource.line
-                # This catches when 'new_resource.pattern' matches line on
-                # first pass but fails on second pass appending the line
-                # to the bottom of temp_file.
-                found = true
               end
               temp_file.puts line
             end

--- a/spec/replace_or_add_spec.rb
+++ b/spec/replace_or_add_spec.rb
@@ -225,13 +225,12 @@ describe 'replace_or_add lines in a missing file' do
   end
 end
 
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 def file_replacement
-  allow(::File).to receive(:exists?).and_call_original
+  allow(::File).to receive(:exist?).and_call_original
   allow(Tempfile).to receive(:new).and_call_original
   allow(FileUtils).to receive(:copy_file).and_call_original
   # Specific replacements
-  allow(::File).to receive(:exists?).with('file').and_return(true)
+  allow(::File).to receive(:exist?).with('file').and_return(true)
   fake_file = StringIO.open(@file_content)
   fake_lstat = double
   allow(::File).to receive(:open).with('file', 'r+').and_return(fake_file)
@@ -247,7 +246,7 @@ def file_replacement
   allow(FileUtils).to receive(:chown)
   allow(FileUtils).to receive(:chmod)
   missing_file = double
-  allow(::File).to receive(:exists?).with('missingfile').and_return(false)
+  allow(::File).to receive(:exist?).with('missingfile').and_return(false)
   allow(::File).to receive(:open).with('missingfile', 'w').and_return(missing_file)
   allow(missing_file).to receive(:puts) { |line| @file_content << "#{line}\n" }
   allow(missing_file).to receive(:close)


### PR DESCRIPTION
Fixed the test stubs.
Revert PR #29 changes.  #30 already had that function.

Running rubocop changed the code to use the exist? method instead of exists?. The rspec test fail quite badly after that change. I updated the rspec stubs to reflect the code change. The code to check for the replacement line in PR #29 partially duplicated function introduced by #30. The #29 code was not needed as I deleted it.

Thanks,
   Mark
