### PR TITLE
replace_only:  Add a replace_only option to replace_or_add

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ the resoures.
       line "Why hello there, you beautiful person, you."
     end
 
+    replace_or_add "change the love, don't add more" do
+      path "/some/file"
+      pattern "Why hello there.*"
+      line "Why hello there, you beautiful person, you."
+      replace_only true
+    end
+
     delete_lines "remove hash-comments from /some/file" do
       path "/some/file"
       pattern "^#.*"

--- a/libraries/provider_replace_or_add.rb
+++ b/libraries/provider_replace_or_add.rb
@@ -55,7 +55,7 @@ class Chef
               temp_file.puts line
             end
 
-            unless found # "add"!
+            unless found || new_resource.replace_only # "add"!
               temp_file.puts new_resource.line
               modified = true
             end
@@ -78,8 +78,10 @@ class Chef
 
           begin
             nf = ::File.open(new_resource.path, 'w')
-            nf.puts new_resource.line
-            new_resource.updated_by_last_action(true)
+            unless new_resource.replace_only
+              nf.puts new_resource.line
+              new_resource.updated_by_last_action(true)
+            end
           rescue ENOENT
             Chef::Log.info('ERROR: Containing directory does not exist for #{nf.class}')
           ensure

--- a/libraries/resource_replace_or_add.rb
+++ b/libraries/resource_replace_or_add.rb
@@ -50,6 +50,14 @@ class Chef
           kind_of: String
         )
       end
+
+      def replace_only(arg = nil)
+        set_or_return(
+          :replace_only,
+          arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
     end
   end
 end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_missing_02.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_missing_02.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2015, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'missing_file' do
+  path 'missingfile'
+  pattern '^add this'
+  line 'add this line'
+  replace_only true
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_replace_only_match.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_replace_only_match.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2016, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'replace_only' do
+  path 'file'
+  pattern 'Identical line'
+  line 'Replace duplicate lines'
+  replace_only true
+end

--- a/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_replace_only_nomatch.rb
+++ b/spec/fixtures/cookbooks/line_tests/recipes/replace_or_add_replace_only_nomatch.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: line_tests
+#
+# Copyright 2016, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+replace_or_add 'replace_only_no_match' do
+  path 'file'
+  pattern 'Does not match'
+  line 'Replace duplicate lines'
+  replace_only true
+end

--- a/spec/replace_or_add_spec.rb
+++ b/spec/replace_or_add_spec.rb
@@ -191,6 +191,34 @@ describe 'replace_or_add lines in an existing file' do
       end
     end
   end
+
+  context 'when replace_only is specified' do
+    describe 'when lines match' do
+      before { chef_run.converge('line_tests::replace_or_add_replace_only_match') }
+      it 'should change both lines' do
+        expect(@file_content.scan(/^Replace duplicate lines$/).size).to eq(2)
+      end
+      it 'should not add lines' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'should flag the resource change' do
+        expect(chef_run).to edit_replace_or_add('replace_only').with(updated_by_last_action?: true)
+      end
+    end
+
+    describe 'when no lines match' do
+      before { chef_run.converge('line_tests::replace_or_add_replace_only_nomatch') }
+      it 'should change no lines' do
+        expect(@file_content.scan(/^Replace duplicate lines$/).size).to eq(0)
+      end
+      it 'should not add lines' do
+        expect(@file_content.lines.count).to eq(testfile_size)
+      end
+      it 'should not flag the resource change' do
+        expect(chef_run).to edit_replace_or_add('replace_only_no_match').with(updated_by_last_action?: false)
+      end
+    end
+  end
 end
 
 describe 'replace_or_add lines in a missing file' do
@@ -223,6 +251,17 @@ describe 'replace_or_add lines in a missing file' do
       expect(chef_run).to edit_replace_or_add('missing_file').with(updated_by_last_action?: true)
     end
   end
+
+  context 'when replace_only is true' do
+    before { chef_run.converge('line_tests::replace_or_add_missing_02') }
+    it 'should not add a line' do
+      expect(@file_content.scan(/^add this line$/).size).to eq(0)
+    end
+    it 'should flag the resource change' do
+      expect(chef_run).to edit_replace_or_add('missing_file').with(updated_by_last_action?: false)
+    end
+  end
+
 end
 
 def file_replacement


### PR DESCRIPTION
Allow replace or add to replace lines without adding lines if the pattern doesn't match.
Should fix issue #38.
