### PR TITLE
#42 - Handle lists enclosed by some characters

### DIFF
--- a/libraries/provider_add_to_list.rb
+++ b/libraries/provider_add_to_list.rb
@@ -48,15 +48,23 @@ class Chef
             f.each_line do |line|
               if line =~ regex
                 found = true
-                if new_resource.delim.count == 1
-                  unless line =~ /(#{new_resource.delim[0]}|#{new_resource.pattern})\s*#{new_resource.entry}\s*(#{new_resource.delim[0]}|\n)/
-                    line = line.chomp + "#{new_resource.delim[0]}#{new_resource.entry}"
+                if new_resource.ends_with
+                  unless line =~ /(#{new_resource.delim[0]}|#{new_resource.pattern}).+#{new_resource.entry}(#{new_resource.delim[0]}|#{new_resource.ends_with}|\n)/
+                    list_end = line.rindex(new_resource.ends_with)
+                    line = line.chomp.insert(list_end, "#{new_resource.delim[0]}#{new_resource.entry}")
                     modified = true
                   end
                 else
-                  unless line =~ /#{new_resource.delim[0]}\s*#{new_resource.entry}\s*#{new_resource.delim[1]}/
-                    line = line.chomp + "#{new_resource.delim[0]}#{new_resource.entry}#{new_resource.delim[1]}"
-                    modified = true
+                  if new_resource.delim.count == 1
+                    unless line =~ /(#{new_resource.delim[0]}|#{new_resource.pattern})\s*#{new_resource.entry}\s*(#{new_resource.delim[0]}|\n)/
+                      line = line.chomp + "#{new_resource.delim[0]}#{new_resource.entry}"
+                      modified = true
+                    end
+                  else
+                    unless line =~ /#{new_resource.delim[0]}\s*#{new_resource.entry}\s*#{new_resource.delim[1]}/
+                      line = line.chomp + "#{new_resource.delim[0]}#{new_resource.entry}#{new_resource.delim[1]}"
+                      modified = true
+                    end
                   end
                 end
               end

--- a/libraries/provider_add_to_list.rb
+++ b/libraries/provider_add_to_list.rb
@@ -58,7 +58,7 @@ class Chef
                     line = line.chomp + "#{new_resource.delim[0]}#{new_resource.entry}#{new_resource.delim[1]}"
                     modified = true
                   end
-                            end
+                end
               end
               temp_file.puts line
             end

--- a/libraries/resource_add_to_list.rb
+++ b/libraries/resource_add_to_list.rb
@@ -58,6 +58,15 @@ class Chef
           kind_of: String
         )
       end
+
+      def ends_with(arg = nil)
+        set_or_return(
+          :ends_with,
+          arg,
+          kind_of: String
+        )
+      end
+
     end
   end
 end

--- a/tests/cookbooks/line_test/recipes/default.rb
+++ b/tests/cookbooks/line_test/recipes/default.rb
@@ -172,3 +172,11 @@ end
 #   delim [", ", "[", "]"]
 #   entry "818"
 # end
+
+add_to_list 'Operation 19' do
+    path '/tmp/dangerfile3'
+    pattern 'my @net1918 ='
+    delim [', ']
+    ends_with ");"
+    entry '"127.0.0.0/8"'
+end


### PR DESCRIPTION
This adds an `ends_with` optional parameter to accept a character or sub-string which overrides the existing logic and instead simply indexes the end of the list (based on the ends_with match in revers [rindex]) rather than the string end or delimiter end allowing the modification of lists which are quoted, or bracketed. 
