### PR TITLE
also define the matcher in chefspec

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -9,6 +9,7 @@ if defined?(ChefSpec)
 
   custom_resources.each do |resource, actions|
     actions.each do |action|
+      ChefSpec.define_matcher resource
       define_method("#{action}_#{resource}") do |message|
         ChefSpec::Matchers::ResourceMatcher
           .new(resource.to_sym, action, message)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description 'Provides line editing resources for use by recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version      '1.0.1'
+version      '1.0.2'
 source_url   'https://github.com/sous-chefs/line-cookbook'
 issues_url   'https://github.com/sous-chefs/line-cookbook/issues'
 chef_version '>= 12.5' if respond_to?(:chef_version)


### PR DESCRIPTION
Without defining the matcher we get errors like:
```
Failures:

  1) cookbook_name::recipe_name example description
     Failure/Error: expect(chef_run.replace_or_add('resrouce name')).to notify('execute[a test]').to(:run).immediately

     NoMethodError:
       undefined method `replace_or_add' for #<ChefSpec::SoloRunner:0x007fbbb70339d0>
     # ./spec/unit/recipes/recipe_name_spec.rb:28:in `block (3 levels) in <top (required)>'
```
and spec fails.
Defining the matcher makes the specs happy.

I think this was missed in this [commit](https://github.com/sous-chefs/line-cookbook/commit/38ad31ae77021fb01bec24a97d4ec673dda337a9#diff-a553601dd58368aaf6772dcfa59c1951) and this [commit](https://github.com/sous-chefs/line-cookbook/commit/b2eaab97ee6f72fe9696ddb004e2520f21144759#diff-a553601dd58368aaf6772dcfa59c1951).

Keeping these specs [here](https://github.com/sous-chefs/line-cookbook/commit/ae37b7b60585c2519eac58cc311ca9f42da08f26) and [here](https://github.com/sous-chefs/line-cookbook/commit/055c393d0e2b7f6e333c03816345d996efa42729) might have caught the error, not sure why they were removed. In my opinion those specs should be added back or at least one that tests the matchers.

Cheers,