### PR TITLE
Match lines containing question mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # line Cookbook CHANGELOG
 
+- Add question mark to regular expression escape characters
+
 ## v1.0.5 (2018-02-20)
 
 - Minor Testing updates

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -21,7 +21,7 @@
 module Line
   module Helper
     def escape_string(string)
-      pattern = %r{(\+|\'|\"|\.|\*|\/|\-|\\|\(|\)|\{|\}|\^|\$|\[|\])}
+      pattern = %r{(\?|\+|\'|\"|\.|\*|\/|\-|\\|\(|\)|\{|\}|\^|\$|\[|\])}
       string.gsub(pattern) { |match| '\\' + match }
     end
 

--- a/test/fixtures/cookbooks/test/recipes/append_if_no_line.rb
+++ b/test/fixtures/cookbooks/test/recipes/append_if_no_line.rb
@@ -13,3 +13,13 @@ append_if_no_line 'Operation redo' do
   path '/tmp/dangerfile'
   line 'HI THERE I AM STRING'
 end
+
+append_if_no_line 'with special chars' do
+  path '/tmp/dangerfile'
+  line 'AM I A STRING?+\'".*/-\(){}^$[]'
+end
+
+append_if_no_line 'with special chars redo' do
+  path '/tmp/dangerfile'
+  line 'AM I A STRING?+\'".*/-\(){}^$[]'
+end

--- a/test/integration/append_if_no_line/inspec/controls/append_if_no_line_spec.rb
+++ b/test/integration/append_if_no_line/inspec/controls/append_if_no_line_spec.rb
@@ -7,7 +7,11 @@ control 'Append lines' do
     its(:count) { should eq 1 }
   end
 
+  describe matches('/tmp/dangerfile', 'AM I A STRING?+\'".*/-\(){}^$[]') do
+    its(:count) { should eq 1 }
+  end
+
   describe file_ext('/tmp/dangerfile') do
-    its(:size_lines) { should eq 5 }
+    its(:size_lines) { should eq 6 }
   end
 end


### PR DESCRIPTION
The append_if_no_line resource was not correctly identifying the
presence of a line if that line had a question mark, due to the question
mark being interpreted as part of the regex. As a result the line would
be appended every chef run. This commit adds the question mark character
to the list of characters to escape in Line::Helper.escape_string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line-cookbook/73)
<!-- Reviewable:end -->
