### PR TITLE
rework append_if_no_line to use file provider subresource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # line Cookbook CHANGELOG
 
+## 1.0.7 (2018-03-28)
+
+- Rework `append_if_no_line` to use file provider subresource.
+- Fix edge conditions around files-with-no-trailing-CR being fed to `append_if_no_line`.
+
 ## 1.0.6 (2018-03-23)
 
 - Add question mark to regular expression escape characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # line Cookbook CHANGELOG
 
-## 1.0.7 (2018-03-28)
+## 1.0.7 (2018-03-23)
 
 - Rework `append_if_no_line` to use file provider subresource.
 - Fix edge conditions around files-with-no-trailing-CR being fed to `append_if_no_line`.

--- a/resources/append_if_no_line.rb
+++ b/resources/append_if_no_line.rb
@@ -4,18 +4,18 @@ property :line, String
 resource_name :append_if_no_line
 
 action :edit do
-  string = escape_string new_resource.line
+  string = Regexp.escape(new_resource.line)
   regex = /^#{string}$/
 
   current = ::File.readlines(new_resource.path)
+  # we match the regexp after doing this append for files without terminating CRs.  should
+  # we instead match against the unchanged content?  we're basically saying "don't worry
+  # about terminating CRs or not, we gotcha covered" which feels like the 99% use case.  but
+  # is there a 1% use case here which considers this a bug?
   current[-1] = current[-1].chomp + "\n"
 
   file new_resource.path do
     content((current + [new_resource.line + "\n"]).join)
     not_if { ::File.exist?(new_resource.path) && !current.grep(regex).empty? }
   end
-end
-
-action_class.class_eval do
-  include Line::Helper
 end

--- a/resources/append_if_no_line.rb
+++ b/resources/append_if_no_line.rb
@@ -11,7 +11,7 @@ action :edit do
   current[-1] = current[-1].chomp + "\n"
 
   file new_resource.path do
-    content ( current + [ new_resource.line + "\n" ] ).join
+    content((current + [new_resource.line + "\n"]).join)
     not_if { ::File.exist?(new_resource.path) && !current.grep(regex).empty? }
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/append_if_no_line.rb
+++ b/test/fixtures/cookbooks/test/recipes/append_if_no_line.rb
@@ -23,3 +23,21 @@ append_if_no_line 'with special chars redo' do
   path '/tmp/dangerfile'
   line 'AM I A STRING?+\'".*/-\(){}^$[]'
 end
+
+file '/tmp/file_without_linereturn' do
+  content 'no carriage return line'
+end
+
+append_if_no_line 'should go on its own line' do
+  path '/tmp/file_without_linereturn'
+  line 'SHOULD GO ON ITS OWN LINE'
+end
+
+file '/tmp/file_without_linereturn2' do
+  content 'no carriage return line'
+end
+
+append_if_no_line 'should not edit the file' do
+  path '/tmp/file_without_linereturn'
+  line 'no carriage return line'
+end

--- a/test/integration/append_if_no_line/inspec/controls/append_if_no_line_spec.rb
+++ b/test/integration/append_if_no_line/inspec/controls/append_if_no_line_spec.rb
@@ -14,4 +14,12 @@ control 'Append lines' do
   describe file_ext('/tmp/dangerfile') do
     its(:size_lines) { should eq 6 }
   end
+
+  describe file('/tmp/file_without_linereturn') do
+    its(:content) { should eql("no carriage return line\nSHOULD GO ON ITS OWN LINE\n") }
+  end
+
+  describe file('/tmp/file_without_linereturn2') do
+    its(:content) { should eql('no carriage return line') }
+  end
 end


### PR DESCRIPTION
there's a ton of the guts of the file provider missing if you don't do this.

as a concrete example here what this is doing is opening a file and then just appending to it, without going through writing it out to a tempfile and moving it into place.

you're missing all of this machinery:

https://stackoverflow.com/a/4174125/506908

which will have horrible edge conditions in situations when you run out of disk space trying to do the append, etc.

also added some tests around files-with-no-terminating-carriage-return which fail on master (badly, actually)...

```
     ×  File /tmp/file_without_linereturn content should eql "no carriage return line\nSHOULD GO ON ITS OWN LINE\n"

     expected: "no carriage return line\nSHOULD GO ON ITS OWN LINE\n"
          got: "no carriage return lineSHOULD GO ON ITS OWN LINE\nno carriage return line\n"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line-cookbook/74)
<!-- Reviewable:end -->
