### PR TITLE
Non slurpy append_if_no_line

### DIFF
--- a/libraries/hacky_file_provider.rb
+++ b/libraries/hacky_file_provider.rb
@@ -1,0 +1,25 @@
+require 'tempfile'
+
+class LineCookbook
+  class HackyFileProvider < Chef::Provider::File
+    provides :hacky_file
+
+    class HackyContent < Chef::FileContentManagement::ContentBase
+      def file_for_provider
+        new_resource.injected_tempfile
+      end
+    end
+
+    def initialize(new_resource, run_context)
+      @content_class = HackyContent
+      super
+    end
+  end
+
+  class HackyFileResource < Chef::Resource::File
+    resource_name :hacky_file
+    provides :hacky_file
+
+    property :injected_tempfile, Tempfile
+  end
+end

--- a/resources/append_if_no_line.rb
+++ b/resources/append_if_no_line.rb
@@ -7,15 +7,23 @@ action :edit do
   string = Regexp.escape(new_resource.line)
   regex = /^#{string}$/
 
-  current = ::File.readlines(new_resource.path)
-  # we match the regexp after doing this append for files without terminating CRs.  should
-  # we instead match against the unchanged content?  we're basically saying "don't worry
-  # about terminating CRs or not, we gotcha covered" which feels like the 99% use case.  but
-  # is there a 1% use case here which considers this a bug?
-  current[-1] = current[-1].chomp + "\n"
+  temp_file = Tempfile.new('line-cookbook')
 
-  file new_resource.path do
-    content((current + [new_resource.line + "\n"]).join)
-    not_if { ::File.exist?(new_resource.path) && !current.grep(regex).empty? }
+  found = false
+  if ::File.exist?(new_resource.path)
+    source = ::File.open(new_resource.path, 'r+')
+    source.each_line do |line|
+      found = true if line =~ regex
+      temp_file.puts line
+    end
+  end
+
+  unless found
+    temp_file.puts new_resource.line
+    temp_file.close
+
+    hacky_file new_resource.path do
+      injected_tempfile temp_file
+    end
   end
 end


### PR DESCRIPTION
this i think is more or less what it would take to make
append_if_no_line both robust via using the file resource, and
to make it non-slurpy.  it passes tests and should do a single
pass across the target file and then use the file provider
machinery to move it into place.

i'm going to close this because i think its getting pretty hacky.

its possible we should patch the core file provider to make this
use case possible without hacking it up.

if there's legit bug reports where the slurpy behavior is shown
to impact people i'd support resurrecting and merging this to fix it.

and i'm submitting this as a PR just as documentation for my future
self for things to think about in core chef.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line-cookbook/76)
<!-- Reviewable:end -->
