### PR TITLE
New property: ignore_missing

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -29,6 +29,9 @@ suites:
 - name: delete_from_list
   run_list:
     - recipe[test::delete_from_list]
+- name: delete_from_list_ignore_missing_file
+  run_list:
+    - recipe[test::delete_from_list_ignore_missing_file]
 - name: add_to_list
   run_list:
     - recipe[test::add_to_list]
@@ -38,6 +41,9 @@ suites:
 - name: delete_lines
   run_list:
     - recipe[test::delete_lines]
+- name: delete_lines_ignore_missing_file
+  run_list:
+    - recipe[test::delete_lines_ignore_missing_file]
 - name: replace_or_add
   run_list:
     - recipe[test::resource_status]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,6 +18,9 @@ suites:
 - name: delete_from_list
   run_list:
     - recipe[test::delete_from_list]
+- name: delete_from_list_ignore_missing_file
+  run_list:
+    - recipe[test::delete_from_list_ignore_missing_file]
 - name: add_to_list
   run_list:
     - recipe[test::add_to_list]
@@ -27,6 +30,9 @@ suites:
 - name: delete_lines
   run_list:
     - recipe[test::delete_lines]
+- name: delete_lines_ignore_missing_file
+  run_list:
+    - recipe[test::delete_lines_ignore_missing_file]
 - name: replace_or_add
   run_list:
     - recipe[test::resource_status]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ delete_from_list "delete entry from a list" do
   delim [","]
   entry "Bobby"
 end
+
+delete_lines 'remove from nonexisting' do
+  path '/tmp/doesnotexist'
+  pattern /^#/
+  ignore_missing true
+end
 ```
 
 # Notes
@@ -90,9 +96,17 @@ end_with is an optional property. If specified a list is expected to end with th
     
 ## delete_from_list
 Works exactly the same way as `add_to_list`, see above.
+
+The property `ignore_missing` defines if operating on a non-existing file raises an error or not.
 	        
 More to follow.
 
+## delete_lines
+
+Removes lines based on a string or regex.
+
+The property `ignore_missing` defines if operating on a non-existing file raises an error or not.
+
 # Author
-Author:: Sean OMeara (<sean@sean.io>)
-Contributor:: Antek S. Baranski (<antek.baranski@gmail.com>)
+Author: Sean OMeara (<sean@sean.io>)  
+Contributor: Antek S. Baranski (<antek.baranski@gmail.com>)

--- a/resources/delete_from_list.rb
+++ b/resources/delete_from_list.rb
@@ -2,11 +2,14 @@ property :path, String
 property :pattern, [String, Regexp]
 property :delim, Array
 property :entry, String
+property :ignore_missing, [TrueClass, FalseClass], default: false
 
 resource_name :delete_from_list
 
 action :edit do
   regex = new_resource.pattern.is_a?(String) ? /#{new_resource.pattern}/ : new_resource.pattern
+
+  return if !::File.exist?(new_resource.path) && new_resource.ignore_missing
 
   raise "File #{new_resource.path} not found" unless ::File.exist?(new_resource.path)
 

--- a/resources/delete_lines.rb
+++ b/resources/delete_lines.rb
@@ -1,10 +1,13 @@
 property :path, String
 property :pattern, [String, Regexp]
+property :ignore_missing, [TrueClass, FalseClass], default: false
 
 resource_name :delete_lines
 
 action :edit do
   regex = new_resource.pattern.is_a?(String) ? /#{new_resource.pattern}/ : new_resource.pattern
+
+  return if !::File.exist?(new_resource.path) && new_resource.ignore_missing
 
   raise "File #{new_resource.path} not found" unless ::File.exist?(new_resource.path)
 

--- a/test/fixtures/cookbooks/test/recipes/delete_from_list_ignore_missing_file.rb
+++ b/test/fixtures/cookbooks/test/recipes/delete_from_list_ignore_missing_file.rb
@@ -1,0 +1,7 @@
+delete_from_list 'missing_file' do
+  path '/tmp/nofilehere'
+  pattern 'multi = '
+  delim [', ', '[', ']']
+  entry '425'
+  ignore_missing true
+end

--- a/test/fixtures/cookbooks/test/recipes/delete_lines_ignore_missing_file.rb
+++ b/test/fixtures/cookbooks/test/recipes/delete_lines_ignore_missing_file.rb
@@ -1,0 +1,5 @@
+delete_lines 'missing_file' do
+  path '/tmp/nofilehere'
+  pattern '^#.*'
+  ignore_missing true
+end


### PR DESCRIPTION
Adds a new property `ignore_missing` to `delete_lines` and `delete_from_list`. This property allows to apply the resource even if the target file might not exist without raising an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line-cookbook/82)
<!-- Reviewable:end -->
