### PR TITLE
Append trailing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # line Cookbook CHANGELOG
 
 ## v2.0.2 (2018-06-29)
-- Explicitly disallow embedded EOL characters in replace and append lines
+- Explicitly disallow embedded EOL characters in replacement and append lines
 
 ## v2.0.1 (2018-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # line Cookbook CHANGELOG
 
+## v2.0.2 (2018-06-29)
+- Explicitly disallow embedded EOL characters in replace and append lines
+
 ## v2.0.1 (2018-06-01)
 
 - Tested on chef 12.13.37.  Fix error caused by using the sensitive attribute.  Sensitive true will always be used for chef 12.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Quite often, the need arises to do line editing instead of managing an entire fi
 - The end of line processing was only tested using`\n` and `\r\n`. Using other line endings very well may not work.
 - The end of line string used needs to match the actual end of line used in the file `\n` and `\r\n` are used as the defaults but if they don't match the actual end of line used in the file the results will be weird.
 - Adding a line implies there is a separator on the previous line. Adding a line differs from appending characters.
+- Lines to be added should not contain EOL characters. The providers do not do multiline regex checks.
 - Missing file processing is the way it is by intention
 
   - `add_to_list` do nothing, list not found so there is nothing to add to.

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -1,6 +1,6 @@
 module Line
   module Helper
-    def embedded_eol(line)
+    def chomp_eol(line)
       fixed = line.chomp(new_resource.eol)
       raise ArgumentError, "Line #{line} has embedded EOL characters, not allowed for this resource" if fixed =~ /#{new_resource.eol}/
       fixed

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -1,5 +1,11 @@
 module Line
   module Helper
+    def embedded_eol(line)
+      fixed = line.chomp(new_resource.eol)
+      raise ArgumentError, "Line #{line} has embedded EOL characters, not allowed for this resource" if fixed =~ /#{new_resource.eol}/
+      fixed
+    end
+
     def default_eol
       new_resource.eol = platform_family?('windows') ? "\r\n" : "\n" unless property_is_set?(:eol)
       new_resource.eol

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Provides line editing resources for use by recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.1'
+version          '2.0.2'
 source_url       'https://github.com/sous-chefs/line-cookbook'
 issues_url       'https://github.com/sous-chefs/line-cookbook/issues'
 chef_version     '>= 12.13.37'

--- a/resources/append_if_no_line.rb
+++ b/resources/append_if_no_line.rb
@@ -10,12 +10,13 @@ action :edit do
   raise_not_found
   sensitive_default
   eol = default_eol
-  string = Regexp.escape(new_resource.line)
+  add_line = embedded_eol(new_resource.line)
+  string = Regexp.escape(add_line)
   regex = /^#{string}$/
   current = target_current_lines
 
   file new_resource.path do
-    content((current + [new_resource.line + eol]).join(eol))
+    content((current + [add_line + eol]).join(eol))
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { ::File.exist?(new_resource.path) && !current.grep(regex).empty? }

--- a/resources/append_if_no_line.rb
+++ b/resources/append_if_no_line.rb
@@ -10,7 +10,7 @@ action :edit do
   raise_not_found
   sensitive_default
   eol = default_eol
-  add_line = embedded_eol(new_resource.line)
+  add_line = chomp_eol(new_resource.line)
   string = Regexp.escape(add_line)
   regex = /^#{string}$/
   current = target_current_lines

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -12,7 +12,7 @@ action :edit do
   raise_not_found
   sensitive_default
   eol = default_eol
-  add_line = embedded_eol(new_resource.line)
+  add_line = chomp_eol(new_resource.line)
   found = false
   regex = new_resource.pattern.is_a?(String) ? /#{new_resource.pattern}/ : new_resource.pattern
   new = []
@@ -23,7 +23,7 @@ action :edit do
     line = line.dup
     if line =~ regex || line == add_line
       found = true
-      line = add_line unless line == add_line
+      line = add_line
     end
     new << line
   end

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -12,6 +12,7 @@ action :edit do
   raise_not_found
   sensitive_default
   eol = default_eol
+  add_line = embedded_eol(new_resource.line)
   found = false
   regex = new_resource.pattern.is_a?(String) ? /#{new_resource.pattern}/ : new_resource.pattern
   new = []
@@ -20,15 +21,15 @@ action :edit do
   # replace
   current.each do |line|
     line = line.dup
-    if line =~ regex || line == new_resource.line
+    if line =~ regex || line == add_line
       found = true
-      line = new_resource.line unless line == new_resource.line
+      line = add_line unless line == add_line
     end
     new << line
   end
 
   # add
-  new << new_resource.line unless found || new_resource.replace_only
+  new << add_line unless found || new_resource.replace_only
 
   # Last line terminator
   new[-1] += eol unless new[-1].to_s.empty?

--- a/spec/rspec_helper.rb
+++ b/spec/rspec_helper.rb
@@ -1,0 +1,10 @@
+Dir.glob('libraries/*.rb').each do |lib|
+  require_relative "../#{lib}"
+end
+
+RSpec.configure do |config|
+  config.expose_dsl_globally = true
+  config.mock_with :rspec do |mocks|
+    mocks.allow_message_expectations_on_nil = true
+  end
+end

--- a/spec/unit/library/helper_spec.rb
+++ b/spec/unit/library/helper_spec.rb
@@ -18,7 +18,7 @@
 require 'rspec_helper'
 require 'ostruct'
 
-class Method_Tester
+class MethodTester
   include Line::Helper
   def new_resource
     OpenStruct.new(eol: "\n")
@@ -27,7 +27,7 @@ end
 
 describe 'embedded_eol method' do
   before(:each) do
-    @method_test = Method_Tester.new
+    @method_test = MethodTester.new
   end
 
   it 'should remove trailing eol' do

--- a/spec/unit/library/helper_spec.rb
+++ b/spec/unit/library/helper_spec.rb
@@ -16,18 +16,12 @@
 #
 
 require 'rspec_helper'
-require 'ostruct'
-
-class MethodTester
-  include Line::Helper
-  def new_resource
-    OpenStruct.new(eol: "\n")
-  end
-end
 
 describe 'embedded_eol method' do
   before(:each) do
-    @method_test = MethodTester.new
+    @method_test = Class.new
+    @method_test.extend(Line::Helper)
+    allow(@method_test).to receive(:new_resource).and_return(double('new_resource', eol: "\n"))
   end
 
   it 'should remove trailing eol' do

--- a/spec/unit/library/helper_spec.rb
+++ b/spec/unit/library/helper_spec.rb
@@ -1,0 +1,40 @@
+#
+# Copyright 2018 Sous Chefs
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'rspec_helper'
+require 'ostruct'
+
+class Method_Tester
+  include Line::Helper
+  def new_resource
+    OpenStruct.new(eol: "\n")
+  end
+end
+
+describe 'embedded_eol method' do
+  before(:each) do
+    @method_test = Method_Tester.new
+  end
+
+  it 'should remove trailing eol' do
+    expect(@method_test.embedded_eol("line\n")).to eq("line")
+  end
+
+  it 'should raise error wit embedded eol' do
+    expect { @method_test.embedded_eol("embedded\ninline") }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/unit/library/helper_spec.rb
+++ b/spec/unit/library/helper_spec.rb
@@ -31,7 +31,7 @@ describe 'embedded_eol method' do
   end
 
   it 'should remove trailing eol' do
-    expect(@method_test.embedded_eol("line\n")).to eq("line")
+    expect(@method_test.embedded_eol("line\n")).to eq('line')
   end
 
   it 'should raise error wit embedded eol' do

--- a/spec/unit/library/helper_spec.rb
+++ b/spec/unit/library/helper_spec.rb
@@ -17,7 +17,7 @@
 
 require 'rspec_helper'
 
-describe 'embedded_eol method' do
+describe 'chomp_eol method' do
   before(:each) do
     @method_test = Class.new
     @method_test.extend(Line::Helper)
@@ -25,10 +25,10 @@ describe 'embedded_eol method' do
   end
 
   it 'should remove trailing eol' do
-    expect(@method_test.embedded_eol("line\n")).to eq('line')
+    expect(@method_test.chomp_eol("line\n")).to eq('line')
   end
 
   it 'should raise error with embedded eol' do
-    expect { @method_test.embedded_eol("embedded\ninline") }.to raise_error(ArgumentError)
+    expect { @method_test.chomp_eol("embedded\ninline") }.to raise_error(ArgumentError)
   end
 end

--- a/spec/unit/library/helper_spec.rb
+++ b/spec/unit/library/helper_spec.rb
@@ -34,7 +34,7 @@ describe 'embedded_eol method' do
     expect(@method_test.embedded_eol("line\n")).to eq('line')
   end
 
-  it 'should raise error wit embedded eol' do
+  it 'should raise error with embedded eol' do
     expect { @method_test.embedded_eol("embedded\ninline") }.to raise_error(ArgumentError)
   end
 end


### PR DESCRIPTION
### Description

The nfs cookbook adds lines with trailing blanks.  Append will never match the existing line and will allows append. One of the worst things we can do is add the same line over and over.  This change chomps the input line so that the comparisons work.  The change also checks for other embedded end of line (EOL) characters and raises an error if they are found.  Embedded characters will also cause repeated appends.  Support for Windows made adding lines with EOL characters impossible.

### Issues Resolved

#113

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line-cookbook/114)
<!-- Reviewable:end -->
