### PR TITLE
Add the before filter method

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,7 +36,9 @@ suites:
   run_list:
     - recipe[test::resource_status]
     - recipe[test::filter_lines_after]
+    - recipe[test::filter_lines_before]
     - recipe[test::filter_lines_inline]
+    - recipe[test::filter_lines_multi]
 - name: replace_or_add
   run_list:
     - recipe[test::resource_status]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # line Cookbook CHANGELOG
 
+## v2.2.0 (2018-10-09)
+- Add the before filter method to allow lines to be inserted before a matching line.
+- Add test examples that show combining filters.
+- Add a couple tests of empty file edge cases.
+
 # Unreleased
 -
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ delete_lines 'remove from nonexisting' do
   ignore_missing true
 end
 
-
 filter_lines 'Shift lines to at least 8 leading spaces' do
   path '/some/file'
   filter proc { |current| current.map(|line| line =~ /^ {8}/ ? line : "       #{line}") }
@@ -96,6 +95,8 @@ filter_lines 'Built in example filters' do
     [
     # insert lines after the last match
       { after:  [match_pattern, insert_lines, :last] },
+    # insert lines before the first  match
+      { before: [match_pattern, insert_lines, :first]  },
     ]
   )
 end
@@ -112,7 +113,8 @@ add_to_list       - Add an item to a list
 delete_from_list  - Delete lines that match a pattern
 filter_lines      - Supply a proc or use a sample filter
   Sample filters:
-    after         - Insert lines before a match
+    after         - Insert lines after a matched line
+    before        - Insert lines before a matched lined
 
 ```
 
@@ -132,7 +134,7 @@ path           | File to update                    | String        | Required, n
 line           | Line contents                     | String        | Required, no default
 ignore_missing | Don't fail if the file is missing | true or false | Default is true
 eol            | Alternate line end characters     | String        | default `\n` on unix, `\r\n` on windows
-backup         | Backup before changing            | Boolean       | default false
+backup         | Backup before changing            | Boolean, Integer | default false
 
 ### Notes
 
@@ -156,7 +158,7 @@ line           | Line contents                            | String              
 replace_only   | Don't append only replace matching lines | true or false                | Required, no default
 ignore_missing | Don't fail if the file is missing        | true or false                | Default is true
 eol            | Alternate line end characters            | String                       | default `\n` on unix, `\r\n` on windows
-backup         | Backup before changing                   | Boolean                      | default false
+backup         | Backup before changing                   | Boolean, Integer             | default false
 
 ## Resource: delete_lines
 
@@ -174,7 +176,7 @@ path           | File to update                     | String                    
 pattern        | Regular expression to select lines | Regular expression or String | Required, no default
 ignore_missing | Don't fail if the file is missing  | true or false                | Default is true
 eol            | Alternate line end characters      | String                       | default `\n` on unix, `\r\n` on windows
-backup         | Backup before changing             | Boolean                      | default false
+backup         | Backup before changing             | Boolean, Integer             | default false
 
 ### Notes
 
@@ -199,7 +201,7 @@ entry          | Value to add                       | String                    
 ends_with      | List ending                        | String                       | No default
 ignore_missing | Don't fail if the file is missing  | true or false                | Default is true
 eol            | Alternate line end characters      | String                       | default `\n` on unix, `\r\n` on windows
-backup         | Backup before changing             | Boolean                      | default false
+backup         | Backup before changing             | Boolean, Integer             | default false
 
 ### Notes
 
@@ -251,7 +253,7 @@ entry          | Value to delete                    | String                    
 ends_with      | List ending                        | String                       | No default
 ignore_missing | Don't fail if the file is missing  | true or false                | Default is true
 eol            | Alternate line end characters      | String                       | default `\n` on unix, `\r\n` on windows
-backup         | Backup before changing             | Boolean                      | default false
+backup         | Backup before changing             | Boolean, Integer             | default false
 
 ### Notes
 
@@ -265,13 +267,13 @@ Action | Description
 edit | Use a proc
 
 ### Properties
-Properties | Description | Type | Values and Default
----------------|-------------|--------|--------
-path           | String |  Path to file | Required, no default
-filters        | Array of filters, Proc, Method |  See the filter grammar | Required, no default
-ignore_missing | Don't fail if the file is missing  |  true or false | Default is true
-eol            | Alternate line end characters |  String | default \n on unix, \r\n on windows
-backup         | Backup before changing |  Boolean | default false
+Properties     | Description | Type   | Values and Default
+---------------|-------------|--------|-------------------
+path           | String                             |  Path to file           | Required, no default
+filters        | Array of filters, Proc, Method     |  See the filter grammar | Required, no default
+ignore_missing | Don't fail if the file is missing  |  true or false          | Default is true
+eol            | Alternate line end characters      |  String                 | default \n on unix, \r\n on windows
+backup         | Backup before changing             |  Boolean, Integer       | default false
 
 ### Notes
 The filter_lines resource passes the contents of the path file in an array of lines to a Proc or Method
@@ -299,6 +301,7 @@ Proc    ::= A reference to a proc that has a signature of proc(current lines is 
 Built in Filter | Description | Arguments | arg1 | arg2  | arg3 |
 ----------------|-------------|-----------|--|--|--|
  `:after` | Insert lines after a matching line | Pattern to match | String or Array of lines to insert | `:each`, `:first`, or `:last` to select the matching lines
+ `:before` | Insert lines before a matching line | Pattern to match | String or Array of lines to insert | :each, :first, or :last to select the matching lines
 
 # Author
 

--- a/libraries/before_filter.rb
+++ b/libraries/before_filter.rb
@@ -1,0 +1,69 @@
+#
+# Copyright 2018 Sous Chefs
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Filter to insert lines before a match
+module Line
+  class Filter
+    def before(current, args)
+      # Insert a set of lines before a match of the pattern.
+      # Inserts only the missing lines
+      # Lines are missing if not between matches of the pattern
+      # Inserts do not care about the order of the lines
+      #   :first insert any lines not found (start -> match line) before the first match
+      #   :last insert any lines not found (match.last -1 -> match.last line) before the last match
+      #   :each insert any lines not found (start -> match & match -1 -> match line) before each match
+      # current is an array of lines
+      # args[0] is a pattern to match a line
+      # args[1] is a string or an array of lines to insert before the matched lines
+      # args[2] match instance, each, first, last
+      #
+      # returns array with inserted lines
+      match_pattern = verify_kind(args[0], Regexp)
+      insert_array = [verify_kind(args[1], [Array, String])].flatten
+      select_match = verify_one_of(args[2], [nil, :each, 'each', :first, 'first', :last, 'last']) || :each
+
+      # find lines matching the pattern
+      matches = []
+      current.each_index { |i| matches << i if current[i] =~ match_pattern }
+
+      case select_match
+      when :each
+        previous = -1
+        matches.each do |match|
+          insert_lines = missing_lines_between(current, previous, match, insert_array)
+          current[match] = Replacement.new(current[match], insert_lines, :before)
+          previous = match
+        end
+      when :first
+        if matches.any?
+          previous = -1
+          match = matches.first
+          insert_lines = missing_lines_between(current, previous, match, insert_array)
+          current[match] = Replacement.new(current[match], insert_lines, :before)
+        end
+      when :last
+        if matches.any?
+          previous = matches[-2] || -1
+          match = matches.last
+          insert_lines = missing_lines_between(current, previous, match, insert_array)
+          current[match] = Replacement.new(current[match], insert_lines, :before)
+        end
+      end
+      expand(current)
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Provides line editing resources for use by recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.1.1'
+version          '2.2.0'
 source_url       'https://github.com/sous-chefs/line-cookbook'
 issues_url       'https://github.com/sous-chefs/line-cookbook/issues'
 chef_version     '>= 12.13.37'

--- a/spec/unit/library/filter/before_spec.rb
+++ b/spec/unit/library/filter/before_spec.rb
@@ -1,0 +1,104 @@
+#
+# Copyright 2018 Sous Chefs
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'rspec_helper'
+include Line
+
+describe 'before method' do
+  before(:each) do
+    @filt = Line::Filter.new
+    @ia = %w(line1 line2 line3)
+    @current = %w(line3 line2 line1 c1 line3 line2 c1 line1 c1 c2)
+    @solo_start = %w(c1 linef lineg lineh )
+    @solo_middle = %w(linef c1 lineg )
+    @solo_end = %w(linef lineg lineh c1)
+    @allthere = %w(line3 line2 line1 c1 line3 line2 line1 c1 line1 line2 line3 c1 c2)
+    @allthere_c2 = %w(line3 line2 line1 c1 line3 line2 line1 c1 line1 line2 line3 c1 line1 line2 line3 c2)
+    @first_match_c1 = %w(line3 line2 line1 c1 line3 line2 c1 line1 c1 c2)
+    @last_match_c1 = %w(line3 line2 line1 c1 line3 line2 c1 line1 c1 line1 line2 line3 c2)
+    @pattern_c1 = /c1/
+    @pattern_c1_c2 = /c1|c2/
+  end
+
+  it 'should not insert if no lines match' do
+    expect(@filt.before([], [@pattern_c1, @ia, :each])).to eq([])
+  end
+
+  it 'should not insert if no lines match - first' do
+    expect(@filt.before([], [@pattern_c1, @ia, :first])).to eq([])
+  end
+
+  it 'should not insert if no lines match - last' do
+    expect(@filt.before([], [@pattern_c1, @ia, :last])).to eq([])
+  end
+
+  it 'should insert missing lines before each match of c1' do
+    expect(@filt.before(@current, [@pattern_c1, @ia, :each])).to eq(@allthere)
+  end
+
+  it 'should insert missing lines before each match of c1 and c2' do
+    expect(@filt.before(@current, [@pattern_c1_c2, @ia, :each])).to eq(@allthere_c2)
+  end
+
+  it 'should insert missing lines before the first match of c1 and c2' do
+    expect(@filt.before(@current, [@pattern_c1_c2, @ia, :first])).to eq(@first_match_c1)
+  end
+
+  it 'should insert missing lines before the last match of c1 and c2' do
+    expect(@filt.before(@current, [@pattern_c1_c2, @ia, :last])).to eq(@last_match_c1)
+  end
+
+  it 'should insert before match of the first line - each' do
+    expect(@filt.before(@solo_start, [@pattern_c1, @ia, :each])).to eq(%w(line1 line2 line3 c1 linef lineg lineh))
+  end
+
+  it 'should insert before match of the first line - first' do
+    expect(@filt.before(@solo_start, [@pattern_c1, @ia, :first])).to eq(%w(line1 line2 line3 c1 linef lineg lineh))
+  end
+
+  it 'should insert before match of the first line - last' do
+    expect(@filt.before(@solo_start, [@pattern_c1, @ia, :last])).to eq(%w(line1 line2 line3 c1 linef lineg lineh))
+  end
+
+  it 'should insert before match of the last line - each' do
+    expect(@filt.before(@solo_end, [@pattern_c1, @ia, :each])).to eq(%w(linef lineg lineh line1 line2 line3 c1))
+  end
+
+  it 'should insert before match of the last line - first' do
+    expect(@filt.before(@solo_end, [@pattern_c1, @ia, :first])).to eq(%w(linef lineg lineh line1 line2 line3 c1))
+  end
+
+  it 'should insert before match of the last line - last' do
+    expect(@filt.before(@solo_end, [@pattern_c1, @ia, :last])).to eq(%w(linef lineg lineh line1 line2 line3 c1))
+  end
+
+  it 'should insert before match of a middle line - each' do
+    expect(@filt.before(@solo_middle, [@pattern_c1, @ia, :each])).to eq(%w(linef line1 line2 line3 c1 lineg))
+  end
+
+  it 'should insert before match of a middle line - first' do
+    expect(@filt.before(@solo_middle, [@pattern_c1, @ia, :first])).to eq(%w(linef line1 line2 line3 c1 lineg))
+  end
+
+  it 'should insert before match of a middle line - last' do
+    expect(@filt.before(@solo_middle, [@pattern_c1, @ia, :last])).to eq(%w(linef line1 line2 line3 c1 lineg))
+  end
+
+  it 'should insert a string' do
+    expect(@filt.before(@solo_middle, [@pattern_c1, 'string1', :last])).to eq(%w(linef string1 c1 lineg))
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/filter_lines_before.rb
+++ b/test/fixtures/cookbooks/test/recipes/filter_lines_before.rb
@@ -1,0 +1,51 @@
+#
+# Verify the results of using the before filter
+#
+
+directory '/tmp'
+
+# ==================== before filter =================
+
+insert_lines = %w(line1 line2 line3)
+match_pattern = /^COMMENT ME|^HELLO/
+
+# ==================== before filter =================
+
+template '/tmp/before' do
+  source 'dangerfile.erb'
+  sensitive true
+end
+
+template '/tmp/before_first' do
+  source 'dangerfile.erb'
+  sensitive true
+end
+
+template '/tmp/before_last' do
+  source 'dangerfile.erb'
+  sensitive true
+end
+
+filter_lines 'Insert lines before match' do
+  path '/tmp/before'
+  sensitive false
+  filters before: [match_pattern, insert_lines]
+end
+
+filter_lines 'Insert lines before match' do
+  path '/tmp/before_first'
+  sensitive false
+  filters before: [match_pattern, insert_lines, :first]
+end
+
+filter_lines 'Insert lines last match' do
+  path '/tmp/before_last'
+  sensitive false
+  filters before: [match_pattern, insert_lines, :last]
+end
+
+filter_lines 'Insert lines before match redo' do
+  path '/tmp/before'
+  sensitive false
+  filters before: [match_pattern, insert_lines]
+end

--- a/test/fixtures/cookbooks/test/recipes/filter_lines_multi.rb
+++ b/test/fixtures/cookbooks/test/recipes/filter_lines_multi.rb
@@ -1,0 +1,57 @@
+#
+# Test combinations of filters and edge cases
+#
+
+directory '/tmp'
+
+insert_lines = %w(line1 line2 line3)
+match_pattern = /^COMMENT ME|^HELLO/
+
+# ==================== Multiple filters =================
+
+template '/tmp/multiple_filters' do
+  source 'dangerfile.erb'
+  sensitive true
+end
+
+filter_lines 'Multiple before and after match' do
+  path '/tmp/multiple_filters'
+  sensitive false
+  filters(
+    [
+      # insert lines before the last match
+      { before: [match_pattern, insert_lines, :last] },
+      # insert lines after the last match
+      { after:  [match_pattern, insert_lines, :last] },
+      # delete comment lines
+      proc { |current| current.select { |line| line !~ /^#/ } },
+    ]
+  )
+end
+
+filter_lines 'Multiple before and after match redo' do
+  path '/tmp/multiple_filters'
+  sensitive false
+  filters(
+    [
+      # insert lines before the last match
+      { before: [match_pattern, insert_lines, :last] },
+      # insert lines after the last match
+      { after:  [match_pattern, insert_lines, :last] },
+      # delete comment lines
+      proc { |current| current.select { |line| line !~ /^#/ } },
+    ]
+  )
+end
+
+# =====================
+
+file '/tmp/emptyfile' do
+  content ''
+end
+
+filter_lines 'Do nothing to the empty file' do
+  path '/tmp/emptyfile'
+  sensitive false
+  filters proc { |current| current }
+end

--- a/test/integration/filter_lines/controls/filter_lines_before_spec.rb
+++ b/test/integration/filter_lines/controls/filter_lines_before_spec.rb
@@ -1,0 +1,32 @@
+# ============ before
+control 'filter_lines - Verify the code to use filters. Verify several example filters' do
+  eol = os.family == 'windows' ? "\r\n" : "\n"
+
+  describe file('/tmp/before') do
+    its(:content) { should match(/line1#{eol}line2#{eol}line3#{eol}HELLO THERE/m) }
+    its(:content) { should match(/line1#{eol}line2#{eol}line3#{eol}COMMENT ME/m) }
+  end
+  describe file_ext('/tmp/before') do
+    its('size_lines') { should eq 11 }
+  end
+
+  describe file('/tmp/before_first') do
+    its(:content) { should match(/line1#{eol}line2#{eol}line3#{eol}HELLO THERE/m) }
+    its(:content) { should match(/FOOL#{eol}COMMENT ME/m) }
+  end
+  describe file_ext('/tmp/before_first') do
+    its('size_lines') { should eq 8 }
+  end
+
+  describe file('/tmp/before_last') do
+    its(:content) { should match(/^HELLO THERE/m) }
+    its(:content) { should match(/line1#{eol}line2#{eol}line3#{eol}COMMENT ME/m) }
+  end
+  describe file_ext('/tmp/before_last') do
+    its('size_lines') { should eq 8 }
+  end
+
+  describe file('/tmp/chef_resource_status') do
+    its(:content) { should match(/Insert lines before match redo.*n/) }
+  end
+end

--- a/test/integration/filter_lines/controls/filter_lines_inline_spec.rb
+++ b/test/integration/filter_lines/controls/filter_lines_inline_spec.rb
@@ -4,6 +4,7 @@
 
 control 'filter_lines - Verify the code to use adhoc filters.' do
   eol = os.family == 'windows' ? "\r\n" : "\n"
+
   # ============ inline
 
   # do nothing

--- a/test/integration/filter_lines/controls/filter_lines_multi_spec.rb
+++ b/test/integration/filter_lines/controls/filter_lines_multi_spec.rb
@@ -1,0 +1,15 @@
+
+# ============ multiple filters
+
+control 'filter_lines - Verify the code to use filters. Verify several example filters' do
+  eol = os.family == 'windows' ? "\r\n" : "\n"
+
+  describe file('/tmp/multiple_filters') do
+    its(:content) { should match(/HELLO THERE I AM DANGERFILE#{eol}line1#{eol}line2#{eol}line3#{eol}/m) }
+    its(:content) { should match(/COMMENT ME AND I STOP YELLING I PROMISE#{eol}line1#{eol}line2#{eol}line3#{eol}int/m) }
+    its(:content) { should_not match(/# UNCOMMENT/) }
+  end
+  describe file_ext('/tmp/multiple_filters') do
+    its('size_lines') { should eq 10 }
+  end
+end


### PR DESCRIPTION
### Description

Add the before filter.  Lines can be inserted before matching lines in the file.

### Issues Resolved

None directly

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line/126)
<!-- Reviewable:end -->
