### PR TITLE
Add the substitute filter

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,6 +43,7 @@ suites:
     - recipe[test::filter_lines_inline]
     - recipe[test::filter_lines_multi]
     - recipe[test::filter_lines_replace]
+    - recipe[test::filter_lines_substitute]
 - name: replace_or_add
   run_list:
     - recipe[test::resource_status]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Allow selected lines in a file to be replaced by other lines.
 Safe was the intended behavior.
 - Add missing tests for methods verify_kind and verify_one_of.
 - Allow inserted lines to be specified as strings. Split input strings on EOL characters.
+- Add the substitute filter
 
 ## v2.2.0 (2018-10-09)
 - Add the before filter method to allow lines to be inserted before a matching line.

--- a/libraries/substitute_filter.rb
+++ b/libraries/substitute_filter.rb
@@ -1,0 +1,47 @@
+#
+# Copyright 2018 Sous Chefs
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Filter to substitute in lines that  match
+module Line
+  class Filter
+    def substitute(current, args)
+      # current is an array of lines
+      # args[0] is a pattern to match a line or a string in a line
+      # args[1] is a pattern to match and substitute for, defaults to arg[0]
+      # args[2] is the string or hash to replace the sub pattern with # no embedded EOL characters
+      # args[3] options allowed - safe
+      #
+      # returns array with inserted lines
+      #
+      # error condition - If the substitute string will match a line after replacement
+      #  it is possible for the file size to increase after every converge. Use force
+      # to ignore the possible error.
+      match_pattern = verify_kind(args[0], Regexp)
+      sub_pattern = verify_kind(args[1], [Regexp]) || match_pattern
+      substitute_str = verify_kind(args[2], [NilClass, String, Hash]) # String or Hash
+      options(args[3], safe: [true, false])
+
+      # find lines matching the pattern, then substitute
+      new_lines = current.map do |line|
+        new_line = line =~ match_pattern ? line.gsub(sub_pattern, substitute_str) : line
+        raise ArgumentError, "Warning - The line with contents #{line} will match #{match_pattern} and #{sub_pattern} each chef run" if new_line =~ match_pattern && new_line =~ sub_pattern && @options[:safe]
+        new_line
+      end
+      new_lines
+    end
+  end
+end

--- a/spec/unit/library/filter/substitute_spec.rb
+++ b/spec/unit/library/filter/substitute_spec.rb
@@ -1,0 +1,107 @@
+#
+# Copyright 2018 Sous Chefs
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'rspec_helper'
+include Line
+
+describe 'substitute method' do
+  before(:each) do
+    @filt = Line::Filter.new
+    @filt.safe_default = true
+    @filt.eol = "\n"
+    @current = ['line3', 'line2 Stuff', 'line1', 'c1', 'line3', 'line2 funny', '# c1', 'line1', 'c1', 'c2']
+    @solo_start = %w(c1 linef lineg lineh )
+    @solo_middle = %w(linef c1 lineg )
+    @solo_end = %w(linef lineg lineh c1)
+    @pattern_c1 = /c1/
+    @new_str = 'Replacement'
+    @err_str = 'c1 plus'
+    @pattern_c1_c2 = /c1|c2/
+  end
+
+  it 'should not change if no lines match' do
+    expect(@filt.substitute([], [/^/, @pattern_c1, 'replace'])).to eq([])
+  end
+
+  it 'should substitute each match of c1' do
+    out_lines = @current.map { |line| line }
+    out_lines[3] = 'Replacement'
+    out_lines[6] = '# Replacement'
+    out_lines[8] = 'Replacement'
+    expect(@filt.substitute(@current, [/^/, @pattern_c1, @new_str])).to eq(out_lines)
+  end
+
+  it 'should substitute each match of c1 and c2' do
+    out_lines = @current.map { |line| line }
+    out_lines[3] = 'Replacement'
+    out_lines[6] = '# Replacement'
+    out_lines[8] = 'Replacement'
+    out_lines[9] = 'Replacement'
+    expect(@filt.substitute(@current, [/^/, @pattern_c1_c2, @new_str])).to eq(out_lines)
+  end
+
+  it 'should substitute the first line' do
+    out_lines = @solo_start.map { |line| line }
+    out_lines[0] = 'Replacement'
+    expect(@filt.substitute(@solo_start, [/^/, @pattern_c1, @new_str])).to eq(out_lines)
+  end
+
+  it 'should substitute the middle line' do
+    out_lines = @solo_middle.map { |line| line }
+    out_lines[1] = 'Replacement'
+    expect(@filt.substitute(@solo_middle, [/^/, @pattern_c1, @new_str])).to eq(out_lines)
+  end
+
+  it 'should substitute the end line' do
+    out_lines = @solo_end.map { |line| line }
+    out_lines[3] = 'Replacement'
+    expect(@filt.substitute(@solo_end, [/^/, @pattern_c1, @new_str])).to eq(out_lines)
+  end
+
+  it 'should match a line and use the substitute pattern' do
+    out_lines = @current.map { |line| line }
+    out_lines[1] = 'line2 nonsense'
+    expect(@filt.substitute(@current, [/^line2/, /stuff/i, 'nonsense'])).to eq(out_lines)
+  end
+
+  it 'should match all lines and use the substitute pattern' do
+    out_lines = @current.map { |line| line }
+    out_lines[5] = 'line2 serious'
+    expect(@filt.substitute(@current, [/^/, /funny/i, 'serious'])).to eq(out_lines)
+  end
+
+  it 'should error in case of continuing changes' do
+    out_lines = @current.map { |line| line }
+    out_lines[9] = 'c2 plus error'
+    expect { @filt.substitute(@current, [/^/, /c2/, 'c2 plus error']) }.to raise_error(ArgumentError)
+  end
+
+  it 'should allow force in case of continuing changes' do
+    out_lines = @current.map { |line| line }
+    out_lines[9] = 'c2 plus bypass'
+    expect(@filt.substitute(@current, [/^/, /c2/, 'c2 plus bypass', safe: false])).to eq(out_lines)
+  end
+
+  it 'should use a hash to substitute multiple values' do
+    out_lines = @current.map { |line| line }
+    @current = ['line3', 'line2 Stuff', 'line1', 'c1', 'line3', 'line2 funny', '# c1', 'line1', 'c1', 'c2']
+    out_lines[3] = 'd1'
+    out_lines[8] = 'd1'
+    out_lines[9] = 'd2'
+    expect(@filt.substitute(@current, [/^/, /^c[12]/, { 'c1' => 'd1', 'c2' => 'd2' }, safe: true])).to eq(out_lines)
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/filter_lines_substitute.rb
+++ b/test/fixtures/cookbooks/test/recipes/filter_lines_substitute.rb
@@ -1,0 +1,20 @@
+#
+# Verify the results of using the substitute filter
+#
+
+directory '/tmp'
+
+# ==================== substitute filter =================
+template '/tmp/substitute' do
+  source 'dangerfile3.erb'
+end
+
+filter_lines 'Substitute string for matching pattern' do
+  path '/tmp/substitute'
+  filters substitute: [/last/, /last_list/, 'start_list']
+end
+
+filter_lines 'Substitute string for matching pattern redo' do
+  path '/tmp/substitute'
+  filters substitute: [/last/, /last_list/, 'start_list']
+end

--- a/test/integration/filter_lines/controls/filter_lines_substitue_spec.rb
+++ b/test/integration/filter_lines/controls/filter_lines_substitue_spec.rb
@@ -1,0 +1,17 @@
+#
+# Spec tests for the replace filter
+#
+
+control 'filter_lines_substitute - Verify the code to use the substitute filter.' do
+  describe file('/tmp/substitute') do
+    its(:content) { should match(/start_list/) }
+  end
+
+  describe file_ext('/tmp/substitute') do
+    its('size_lines') { should eq 20 }
+  end
+
+  describe file('/tmp/chef_resource_status') do
+    its(:content) { should match(/Substitute string for matching pattern redo.*n/) }
+  end
+end


### PR DESCRIPTION
### Description

Add the substitute filter.  This filter allows searches with one regex to find lines and substitutions of text that matches another regex.

### Issues Resolved

New feature.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line/144)
<!-- Reviewable:end -->
