### PR TITLE
Fixup filter_lines for chef 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # line Cookbook CHANGELOG
 
+## v2.3.3
+- Fix `filter_lines` to work with Chef12
+
 ## v2.3.2
 - Fix internal documentation references
 - Bump to get a rebuild

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Provides line editing resources for use by recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.3.2'
+version          '2.3.3'
 source_url       'https://github.com/sous-chefs/line'
 issues_url       'https://github.com/sous-chefs/line/issues'
 chef_version     '>= 12.13.37'

--- a/resources/filter_lines.rb
+++ b/resources/filter_lines.rb
@@ -26,7 +26,7 @@ resource_name :filter_lines
 
 action :edit do
   raise_not_found
-  new_resource.sensitive = true unless property_is_set?(:sensitive)
+  sensitive_default
   eol = default_eol
   backup_if_true
 


### PR DESCRIPTION
### Description

Fixes an error with the 'sensitive' property detection on Chef 12 for the `filter_lines` resource.

### Issues Resolved

Fixes issue #160 

### Contribution Check List

- [ x ] All tests pass.
- [NA] New functionality includes testing.
- [NA] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line/161)
<!-- Reviewable:end -->
