### PR TITLE
Chef13 chef15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # line Cookbook CHANGELOG
 
 ## v2.3.3
-- Fix `filter_lines` to work with Chef12
+- Fix `filter_lines` to work with Chef12. The filters helper method matched the name of a resource property.
+Changed the name to avoid the collision.
 
 ## v2.3.2
 - Fix internal documentation references

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,6 +4,9 @@ driver:
 
 provisioner:
   name: chef_zero
+  chef_omnibus_install_options: chef
+  require_chef_omnibus: 14.13.11
+  accept_license: true
 
 client_rb:
   treat_deprecation_warnings_as_errors: true

--- a/libraries/filter_helper.rb
+++ b/libraries/filter_helper.rb
@@ -113,7 +113,7 @@ module Line
 
   class Replacement
     def initialize(original, additional, direction)
-      @original = original.dup
+      @original = original.nil? ? nil : original.dup
       @additional = additional
       @direction = direction # replace, before, after, remove
     end

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -50,17 +50,17 @@ module Line
     end
 
     def filter_method(code)
-      raise ArgumentError, "Unknown filter, #{code}, specified" unless filters.public_methods.include?(code)
-      filters.method(code)
+      raise ArgumentError, "Unknown filter, #{code}, specified" unless filter_rep.public_methods.include?(code)
+      filter_rep.method(code)
     end
 
-    def filters
-      unless @filters
-        @filters ||= Line::Filter.new
-        @filters.safe_default = new_resource.safe
-        @filters.eol = new_resource.eol
+    def filter_rep
+      unless @filter_rep
+        @filter_rep ||= Line::Filter.new
+        @filter_rep.safe_default = new_resource.safe
+        @filter_rep.eol = new_resource.eol
       end
-      @filters
+      @filter_rep
     end
 
     def invoke_filter(code, args)

--- a/spec/unit/library/helper_spec.rb
+++ b/spec/unit/library/helper_spec.rb
@@ -46,7 +46,7 @@ describe 'helper methods' do
 
   describe 'filters' do
     it 'should return a new filter object' do
-      expect(@method_test.filters.class).to eq(Line::Filter)
+      expect(@method_test.filter_rep.class).to eq(Line::Filter)
     end
   end
 


### PR DESCRIPTION
### Description

Fix problems with a name collision over filters.  It was used as a method in the helper module and as a resource property.  It worked in chef 14, but not in chef 13 or 15.

### Issues Resolved

#158 
#159 
#162 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line/164)
<!-- Reviewable:end -->
