### PR TITLE
Rename the match_insert_lines method to match_insert_lines?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # line Cookbook CHANGELOG
 
+## v2.4.1
+- Rename match_insert_lines to match_insert_lines?
+- Add tests for match_insert_lines?
+
 ## v2.4.0
 - Add the replace_between filter to allow replacing all of the lines between two lines that match patterns.
 - Change the test dangerfile name to samplefile.  There was a name conflict between the lint Dangerfile

--- a/libraries/filter_helper.rb
+++ b/libraries/filter_helper.rb
@@ -70,8 +70,8 @@ module Line
       lines || []
     end
 
-    def match_insert_lines(match_pattern, insert_lines, safe)
-      return unless safe
+    def match_insert_lines?(match_pattern, insert_lines, safe)
+      return false unless safe
       insert_lines.any? do |line|
         line =~ match_pattern
       end

--- a/libraries/replace_between.rb
+++ b/libraries/replace_between.rb
@@ -36,10 +36,10 @@ module Line
 
       # The start and end patterns shouldn't match lines inside the insert array unless the bounds match too.
       # if the patterns match an internal replacement line replacing may add lines every time.
-      unless match_insert_lines(start_pattern, insert_array[0..0], @options[:safe]) && [:first, :include].include?(ends)
+      unless match_insert_lines?(start_pattern, insert_array[0..0], @options[:safe]) && [:first, :include].include?(ends)
         verify_insert_lines(start_pattern, insert_array[1..-1], @options[:safe])
       end
-      unless match_insert_lines(end_pattern, insert_array[-1..-1], @options[:safe]) && [:last, :include].include?(ends)
+      unless match_insert_lines?(end_pattern, insert_array[-1..-1], @options[:safe]) && [:last, :include].include?(ends)
         verify_insert_lines(end_pattern, insert_array[0...-1], @options[:safe])
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Provides line editing resources for use by recipes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.4.0'
+version          '2.4.1'
 source_url       'https://github.com/sous-chefs/line'
 issues_url       'https://github.com/sous-chefs/line/issues'
 chef_version     '>= 12.13.37'

--- a/spec/unit/library/filter_helper/match_insert_lines_spec.rb
+++ b/spec/unit/library/filter_helper/match_insert_lines_spec.rb
@@ -1,0 +1,65 @@
+#
+# Copyright:: 2019 Sous Chefs
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'rspec_helper'
+include Line
+
+describe 'match_insert_lines? method safe mode false' do
+  before(:each) do
+    @filt = Line::Filter.new
+    @filt.safe_default = true
+  end
+
+  it 'Should always be false' do
+    expect(@filt.match_insert_lines?(/.*/, %w(), false)).to eq(false)
+  end
+
+  it 'Should always be false' do
+    expect(@filt.match_insert_lines?(/a/, %w(a b c), false)).to eq(false)
+  end
+end
+
+describe 'match_insert_lines? method safe mode true' do
+  before(:each) do
+    @filt = Line::Filter.new
+    @filt.safe_default = true
+  end
+
+  it 'empty array should not match' do
+    expect(@filt.match_insert_lines?(/.*/, [], true)).to eq(false)
+  end
+
+  it 'matching array should matche' do
+    expect(@filt.match_insert_lines?(/a/, %w(a b c), true)).to eq(true)
+  end
+
+  it 'matching an array in the middle should match' do
+    expect(@filt.match_insert_lines?(/a/, %w(b a c), true)).to eq(true)
+  end
+
+  it 'matching an array at the end should match' do
+    expect(@filt.match_insert_lines?(/a/, %w(c b a), true)).to eq(true)
+  end
+
+  it 'matching an array multiple times should match' do
+    expect(@filt.match_insert_lines?(/a/, %w(c b a), true)).to eq(true)
+  end
+
+  it 'not matching an array should not match' do
+    expect(@filt.match_insert_lines?(/d/, %w(c b a), true)).to eq(false)
+  end
+end


### PR DESCRIPTION
Add tests for match_insert_lines?

### Description

Change the name of a boolean routine to match ruby conventions.


### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line/170)
<!-- Reviewable:end -->
