### PR TITLE
Fixes typo in append_if_no_line_missing_file_spec.b

### DIFF
--- a/spec/unit/recipes/append_if_no_line_missing_file_spec.rb
+++ b/spec/unit/recipes/append_if_no_line_missing_file_spec.rb
@@ -19,7 +19,7 @@
 
 require 'chefspec_helper'
 
-describe 'spectest::append_if_no_line_file' do
+describe 'spectest::append_if_no_line_missing_file' do
   let(:chef_run) do
     chef_run = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', step_into: ['append_if_no_line'])
     chef_run.converge(described_recipe)


### PR DESCRIPTION
This commit corrects the file extension and also the spec recipe name in
spec/unit/recipes/append_if_no_line_missing_file_spec.b

# Description

The unit test for append_if_no_line_missing_file had a missing .rb extension and also the incorrect recipe name in the describe block.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line/174)
<!-- Reviewable:end -->
