### PR TITLE
Add new flag on add_or_replace resource to remove duplicated lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Migrate to github actions
 
+## v2.7.0
+
+- Add new property remove_duplicates to add_or_replace resource
+- Update documentation for the default value of the replace_only property in the add_or_replace resource
+
 ## v2.6.0
 
 - Add the :next boundary option to replace_between

--- a/documentation/resources/replace_or_add.md
+++ b/documentation/resources/replace_or_add.md
@@ -8,15 +8,16 @@
 
 ## Properties
 
-| Properties     | Description                              | Type                         | Values and Default                      |
-| -------------- | ---------------------------------------- | ---------------------------- | --------------------------------------- |
-| path           | File to update                           | String                       | Required, no default                    |
-| pattern        | Regular expression to select lines       | Regular expression or String | Required, no default                    |
-| line           | Line contents                            | String                       | Required, no default                    |
-| replace_only   | Don't append only replace matching lines | true or false                | Required, no default                    |
-| ignore_missing | Don't fail if the file is missing        | true or false                | Default is true                         |
-| eol            | Alternate line end characters            | String                       | default `\n` on unix, `\r\n` on windows |
-| backup         | Backup before changing                   | Boolean, Integer             | default false                           |
+| Properties        | Description                              | Type                         | Values and Default                      |
+| --------------    | ---------------------------------------- | ---------------------------- | --------------------------------------- |
+| path              | File to update                           | String                       | Required, no default                    |
+| pattern           | Regular expression to select lines       | Regular expression or String | Required, no default                    |
+| line              | Line contents                            | String                       | Required, no default                    |
+| replace_only      | Don't append only replace matching lines | true or false                | Required, no default                    |
+| remove_duplicates | Remove duplicate lines matching pattern  | true or false                | Required, no default                    |
+| ignore_missing    | Don't fail if the file is missing        | true or false                | Default is true                         |
+| eol               | Alternate line end characters            | String                       | default `\n` on unix, `\r\n` on windows |
+| backup            | Backup before changing                   | Boolean, Integer             | default false                           |
 
 ## Example Usage
 

--- a/documentation/resources/replace_or_add.md
+++ b/documentation/resources/replace_or_add.md
@@ -13,8 +13,8 @@
 | path              | File to update                           | String                       | Required, no default                    |
 | pattern           | Regular expression to select lines       | Regular expression or String | Required, no default                    |
 | line              | Line contents                            | String                       | Required, no default                    |
-| replace_only      | Don't append only replace matching lines | true or false                | Required, no default                    |
-| remove_duplicates | Remove duplicate lines matching pattern  | true or false                | Required, no default                    |
+| replace_only      | Don't append only replace matching lines | true or false                | Default is false                        |
+| remove_duplicates | Remove duplicate lines matching pattern  | true or false                | Default is false                        |
 | ignore_missing    | Don't fail if the file is missing        | true or false                | Default is true                         |
 | eol               | Alternate line end characters            | String                       | default `\n` on unix, `\r\n` on windows |
 | backup            | Backup before changing                   | Boolean, Integer             | default false                           |

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -56,6 +56,7 @@ suites:
       - recipe[test::replace_or_add_add_a_line_matching_pattern]
       - recipe[test::replace_or_add_change_line_eof]
       - recipe[test::replace_or_add_duplicate]
+      - recipe[test::replace_or_add_no_duplicate]
       - recipe[test::replace_or_add_missing_file]
       - recipe[test::replace_or_add_replace_only]
       - recipe[test::replace_or_add_unmatched]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Provides line editing resources for use by recipes'
 
-version          '2.6.0'
+version          '2.7.0'
 
 source_url       'https://github.com/sous-chefs/line'
 issues_url       'https://github.com/sous-chefs/line/issues'

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -4,8 +4,8 @@ property :ignore_missing, [true, false], default: true
 property :line, String
 property :path, String
 property :pattern, [String, Regexp]
-property :replace_only, [true, false]
-property :remove_duplicates, [true, false]
+property :replace_only, [true, false], default: false
+property :remove_duplicates, [true, false], default: false
 
 resource_name :replace_or_add
 

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -17,30 +17,30 @@ action :edit do
   add_line = chomp_eol(new_resource.line)
   found = false
   regex = new_resource.pattern.is_a?(String) ? /#{new_resource.pattern}/ : new_resource.pattern
-  new = []
+  new_content = []
   current = target_current_lines
 
   # replace
   current.each do |line|
-    line = line.dup
     if line =~ regex || line == add_line
-      found = true
+      next if found && new_resource.remove_duplicates
       line = add_line
+      found = true
     end
-    new << line unless new.include?(line) && new_resource.remove_duplicates
+    new_content << line.dup
   end
 
   # add
-  new << add_line unless found || new_resource.replace_only
+  new_content << add_line unless found || new_resource.replace_only
 
   # Last line terminator
-  new[-1] += eol unless new[-1].to_s.empty?
+  new_content[-1] += eol unless new_content[-1].to_s.empty?
 
   file new_resource.path do
-    content new.join(eol)
+    content new_content.join(eol)
     backup new_resource.backup
     sensitive new_resource.sensitive
-    not_if { new == current }
+    not_if { new_content == current }
   end
 end
 

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -5,6 +5,7 @@ property :line, String
 property :path, String
 property :pattern, [String, Regexp]
 property :replace_only, [true, false]
+property :remove_duplicates, [true, false]
 
 resource_name :replace_or_add
 
@@ -26,7 +27,7 @@ action :edit do
       found = true
       line = add_line
     end
-    new << line
+    new << line unless new.include?(line) && new_resource.remove_duplicates
   end
 
   # add

--- a/test/fixtures/cookbooks/test/recipes/replace_or_add_no_duplicate.rb
+++ b/test/fixtures/cookbooks/test/recipes/replace_or_add_no_duplicate.rb
@@ -1,0 +1,36 @@
+#
+# cookbook::test
+#
+# Test the replace_or_add resource.
+# Remove duplicate lines
+#
+
+template '/tmp/no_duplicate' do
+  source 'text_file.erb'
+end
+
+template '/tmp/no_duplicate_replace_only' do
+  source 'text_file.erb'
+end
+
+replace_or_add 'no_duplicate' do
+  path '/tmp/no_duplicate'
+  pattern 'Identical line'
+  line 'Remove duplicate lines'
+  remove_duplicates true
+end
+
+replace_or_add 'no_duplicate redo' do
+  path '/tmp/no_duplicate'
+  pattern 'Identical line'
+  line 'Remove duplicate lines'
+  remove_duplicates true
+end
+
+replace_or_add 'no_duplicate_replace_only' do
+  path '/tmp/no_duplicate_replace_only'
+  replace_only true
+  pattern 'Identical line'
+  line 'Remove duplicate lines'
+  remove_duplicates true
+end

--- a/test/fixtures/cookbooks/test/recipes/replace_or_add_no_duplicate.rb
+++ b/test/fixtures/cookbooks/test/recipes/replace_or_add_no_duplicate.rb
@@ -5,7 +5,11 @@
 # Remove duplicate lines
 #
 
-template '/tmp/no_duplicate' do
+template '/tmp/no_duplicate_double' do
+  source 'text_file.erb'
+end
+
+template '/tmp/no_duplicate_single' do
   source 'text_file.erb'
 end
 
@@ -14,15 +18,22 @@ template '/tmp/no_duplicate_replace_only' do
 end
 
 replace_or_add 'no_duplicate' do
-  path '/tmp/no_duplicate'
+  path '/tmp/no_duplicate_double'
   pattern 'Identical line'
   line 'Remove duplicate lines'
   remove_duplicates true
 end
 
 replace_or_add 'no_duplicate redo' do
-  path '/tmp/no_duplicate'
+  path '/tmp/no_duplicate_double'
   pattern 'Identical line'
+  line 'Remove duplicate lines'
+  remove_duplicates true
+end
+
+replace_or_add 'no_duplicate single line' do
+  path '/tmp/no_duplicate_single'
+  pattern 'Data line'
   line 'Remove duplicate lines'
   remove_duplicates true
 end

--- a/test/integration/replace_or_add/controls/replace_or_add_duplicate.rb
+++ b/test/integration/replace_or_add/controls/replace_or_add_duplicate.rb
@@ -1,11 +1,18 @@
 control 'Change multiple lines with one pass' do
   eol = os.family == 'windows' ? "\r\n" : "\n"
+
   describe matches('/tmp/duplicate', /^Replace duplicate lines#{eol}/) do
     its('count') { should eq 2 }
+  end
+  describe matches('/tmp/duplicate', /^Identical line#{eol}/) do
+    its('count') { should eq 0 }
   end
 
   describe matches('/tmp/duplicate_replace_only', /^Replace duplicate lines#{eol}/) do
     its('count') { should eq 2 }
+  end
+  describe matches('/tmp/duplicate_replace_only', /^Identical line#{eol}/) do
+    its('count') { should eq 0 }
   end
 
   # redo of resource did nothing

--- a/test/integration/replace_or_add/controls/replace_or_add_no_duplicate.rb
+++ b/test/integration/replace_or_add/controls/replace_or_add_no_duplicate.rb
@@ -1,0 +1,22 @@
+control 'Check removed duplicate lines' do
+  eol = os.family == 'windows' ? "\r\n" : "\n"
+
+  describe matches('/tmp/no_duplicate', /^Remove duplicate lines#{eol}/) do
+    its('count') { should eq 1 }
+  end
+  describe matches('/tmp/no_duplicate', /^Identical line#{eol}/) do
+    its('count') { should eq 0 }
+  end
+
+  describe matches('/tmp/no_duplicate_replace_only', /^Remove duplicate lines#{eol}/) do
+    its('count') { should eq 1 }
+  end
+  describe matches('/tmp/no_duplicate_replace_only', /^Identical line#{eol}/) do
+    its('count') { should eq 0 }
+  end
+
+  # redo of resource did nothing
+  describe file('/tmp/chef_resource_status') do
+    its(:content) { should match(/duplicate redo.*n#{eol}/) }
+  end
+end

--- a/test/integration/replace_or_add/controls/replace_or_add_no_duplicate.rb
+++ b/test/integration/replace_or_add/controls/replace_or_add_no_duplicate.rb
@@ -1,11 +1,21 @@
 control 'Check removed duplicate lines' do
   eol = os.family == 'windows' ? "\r\n" : "\n"
 
-  describe matches('/tmp/no_duplicate', /^Remove duplicate lines#{eol}/) do
+  describe matches('/tmp/no_duplicate_double', /^Remove duplicate lines#{eol}/) do
     its('count') { should eq 1 }
   end
-  describe matches('/tmp/no_duplicate', /^Identical line#{eol}/) do
+  describe matches('/tmp/no_duplicate_double', /^Identical line#{eol}/) do
     its('count') { should eq 0 }
+  end
+
+  describe matches('/tmp/no_duplicate_single', /^Remove duplicate lines#{eol}/) do
+    its('count') { should eq 1 }
+  end
+  describe matches('/tmp/no_duplicate_single', /^Data line#{eol}/) do
+    its('count') { should eq 0 }
+  end
+  describe matches('/tmp/no_duplicate_single', /^Identical line#{eol}/) do
+    its('count') { should eq 2 }
   end
 
   describe matches('/tmp/no_duplicate_replace_only', /^Remove duplicate lines#{eol}/) do


### PR DESCRIPTION
# Description

This PR adds a new property on the add_or_replace resource to remove duplicated lines for lines matching the pattern only

let's assume we have a file with:
```
line1
line2
line3
line4
```
If we replace `line2` by `line3`, we end up with a duplicated `line3` content. Sometimes we don't want the duplicates.

## Check List

- [ x ] All tests pass. See TESTING.md for details.
- [ x ] New functionality includes testing.
- [ x ] New functionality has been documented in the README if applicable.
