### PR TITLE
Fix compatibility with Chef 16.1.17+

### DIFF
--- a/resources/add_to_list.rb
+++ b/resources/add_to_list.rb
@@ -8,6 +8,7 @@ property :path, String
 property :pattern, String
 
 resource_name :add_to_list
+provides :add_to_list
 
 action :edit do
   raise_not_found

--- a/resources/append_if_no_line.rb
+++ b/resources/append_if_no_line.rb
@@ -5,6 +5,7 @@ property :line, String
 property :path, String
 
 resource_name :append_if_no_line
+provides :append_if_no_line
 
 action :edit do
   raise_not_found

--- a/resources/delete_from_list.rb
+++ b/resources/delete_from_list.rb
@@ -8,6 +8,7 @@ property :path, String
 property :pattern, [String, Regexp]
 
 resource_name :delete_from_list
+provides :delete_from_list
 
 action :edit do
   return if !target_file_exist? && new_resource.ignore_missing

--- a/resources/delete_lines.rb
+++ b/resources/delete_lines.rb
@@ -5,6 +5,7 @@ property :path, String
 property :pattern, [String, Regexp]
 
 resource_name :delete_lines
+provides :delete_lines
 
 action :edit do
   return if !target_file_exist? && new_resource.ignore_missing

--- a/resources/filter_lines.rb
+++ b/resources/filter_lines.rb
@@ -23,6 +23,7 @@ property :path, String, name_property: true
 property :safe, [true, false], default: true
 
 resource_name :filter_lines
+provides :filter_lines
 
 action :edit do
   raise_not_found

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -8,6 +8,7 @@ property :replace_only, [true, false], default: false
 property :remove_duplicates, [true, false], default: false
 
 resource_name :replace_or_add
+provides :replace_or_add
 
 action :edit do
   raise_not_found


### PR DESCRIPTION
# Description

Since chef/chef@6d14ba02ec07b18eb757315d9665b646470f6f56 resources
need to explicitly use `provides` otherwise users will get an error
such as:

```
[2020-05-28T15:14:56+00:00] FATAL: NoMethodError: undefined method
`append_if_no_line' for cookbook: chefops-ldap, recipe: _homedir
:chef::Recipe
````

This change makes us compatible with Chef 16.1.17+.

## Check List

- [x] All tests pass. See TESTING.md for details. (All the kitchen tests passed locally)
- [x] New functionality includes testing. (no new functionality)
- [x] New functionality has been documented in the README if applicable. (no new functionality)
