### PR TITLE
Restore Chef Infra Client < 16 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+- Restore compatibility with Chef Infra Client < 16
+
 ## 2.8.1 - 2020-06-02
 
 - resolved cookstyle error: resources/add_to_list.rb:10:1 warning: `ChefDeprecations/ResourceUsesOnlyResourceName`

--- a/resources/add_to_list.rb
+++ b/resources/add_to_list.rb
@@ -7,6 +7,7 @@ property :ignore_missing, [true, false], default: true
 property :path, String
 property :pattern, String
 
+resource_name :add_to_list
 provides :add_to_list
 
 action :edit do

--- a/resources/append_if_no_line.rb
+++ b/resources/append_if_no_line.rb
@@ -4,6 +4,7 @@ property :ignore_missing, [true, false], default: true
 property :line, String
 property :path, String
 
+resource_name :append_if_no_line
 provides :append_if_no_line
 
 action :edit do

--- a/resources/delete_from_list.rb
+++ b/resources/delete_from_list.rb
@@ -7,6 +7,7 @@ property :ignore_missing, [true, false], default: true
 property :path, String
 property :pattern, [String, Regexp]
 
+resource_name :delete_from_list
 provides :delete_from_list
 
 action :edit do

--- a/resources/delete_lines.rb
+++ b/resources/delete_lines.rb
@@ -4,6 +4,7 @@ property :ignore_missing, [true, false], default: true
 property :path, String
 property :pattern, [String, Regexp]
 
+resource_name :delete_lines
 provides :delete_lines
 
 action :edit do

--- a/resources/filter_lines.rb
+++ b/resources/filter_lines.rb
@@ -22,6 +22,7 @@ property :ignore_missing, [true, false], default: true
 property :path, String, name_property: true
 property :safe, [true, false], default: true
 
+resource_name :filter_lines
 provides :filter_lines
 
 action :edit do

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -7,6 +7,7 @@ property :pattern, [String, Regexp]
 property :replace_only, [true, false], default: false
 property :remove_duplicates, [true, false], default: false
 
+resource_name :replace_or_add
 provides :replace_or_add
 
 action :edit do


### PR DESCRIPTION
Chef Infra Client 16 needs provides and Chef Infra Client < 16 needs resource_name here. If we support both then we need both.

Signed-off-by: Tim Smith <tsmith@chef.io>