### PR TITLE
Remove code that was needed only for chef 12 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Greately increase the platforms we test in CI
 - Increase the minimum supported Chef version to 15.3 for unified mode
+- Remove code that was only there to support chef 12
 
 ## 2.9.3 - *2020-12-07*
 

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -74,9 +74,6 @@ module Line
 
     def sensitive_default
       new_resource.sensitive = true unless property_is_set?(:sensitive)
-    rescue ArgumentError
-      # chef 12 raises ArgumentError checking property_is_set?
-      new_resource.sensitive = true
     end
 
     def target_current_lines

--- a/spec/unit/library/helper_spec.rb
+++ b/spec/unit/library/helper_spec.rb
@@ -67,14 +67,6 @@ describe 'helper methods' do
       expect(@method_test.sensitive_default).to eq(nil)
       expect(new_resource.sensitive).to eq(false)
     end
-
-    it 'should recover from ArgumentError if property_is_set? is not defined ala chef 12' do
-      new_resource = OpenStruct.new
-      allow(@method_test).to receive(:property_is_set?).with(:sensitive).and_raise(ArgumentError)
-      allow(@method_test).to receive(:new_resource).and_return(new_resource)
-      expect(@method_test.sensitive_default).to eq(true)
-      expect(new_resource.sensitive).to eq(true)
-    end
   end
 
   describe 'target_current_lines?' do


### PR DESCRIPTION
# Description

2 lines of code were left whose purpose was chef 12 compatibility.  Since we require 15.3 as a minimum version they no longer have a purpose.

## Issues Resolved
#167 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
