### PR TITLE
Add file ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Add `owner` and `group` properties to the `append_if_no_line` and `replace_or_add` resources
+- Add corresponding tests
+
 ## 4.1.0 - *2021-08-20*
 
 - Update Inspec Tests

--- a/documentation/resources/append_if_no_line.md
+++ b/documentation/resources/append_if_no_line.md
@@ -15,6 +15,8 @@
 | ignore_missing | Don't fail if the file is missing | true or false    | Default is true                         |
 | eol            | Alternate line end characters     | String           | default `\n` on unix, `\r\n` on windows |
 | backup         | Backup before changing            | Boolean, Integer | default false                           |
+| owner          | Set the `owner` of the file       | String           | no default                              |
+| group          | Set the `group` of the file       | String           | no default                              |
 
 ## Example Usage
 

--- a/documentation/resources/replace_or_add.md
+++ b/documentation/resources/replace_or_add.md
@@ -18,6 +18,8 @@
 | ignore_missing    | Don't fail if the file is missing        | true or false                | Default is true                         |
 | eol               | Alternate line end characters            | String                       | default `\n` on unix, `\r\n` on windows |
 | backup            | Backup before changing                   | Boolean, Integer             | default false                           |
+| owner             | Set the `owner` of the file              | String                       | no default                              |
+| group             | Set the `group` of the file              | String                       | no default                              |
 
 ## Example Usage
 

--- a/resources/append_if_no_line.rb
+++ b/resources/append_if_no_line.rb
@@ -1,7 +1,9 @@
 property :backup, [true, false, Integer], default: false
 property :eol, String
+property :group, String
 property :ignore_missing, [true, false], default: true
 property :line, String
+property :owner, String
 property :path, String
 
 resource_name :append_if_no_line
@@ -20,6 +22,8 @@ action :edit do
 
   file new_resource.path do
     content((current + [add_line + eol]).join(eol))
+    owner new_resource.owner
+    group new_resource.group
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { ::File.exist?(new_resource.path) && !current.grep(regex).empty? }

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -1,7 +1,9 @@
 property :backup, [true, false, Integer], default: false
 property :eol, String
+property :group, String
 property :ignore_missing, [true, false], default: true
 property :line, String
+property :owner, String
 property :path, String
 property :pattern, [String, Regexp]
 property :replace_only, [true, false], default: false
@@ -40,6 +42,8 @@ action :edit do
 
   file new_resource.path do
     content new.join(eol)
+    owner new_resource.owner
+    group new_resource.group
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { new == current }

--- a/test/fixtures/cookbooks/test/recipes/append_if_no_line_empty.rb
+++ b/test/fixtures/cookbooks/test/recipes/append_if_no_line_empty.rb
@@ -2,6 +2,8 @@
 # Append to empty file
 #
 
+user 'test_user'
+
 file '/tmp/emptyfile'
 
 append_if_no_line 'should add to empty file' do
@@ -12,6 +14,13 @@ end
 append_if_no_line 'missing_file' do
   path '/tmp/missing_create'
   line 'added line'
+end
+
+append_if_no_line 'missing_file with owner and group' do
+  path '/tmp/missing_create_owner'
+  line 'Owned by test_user'
+  owner 'test_user'
+  group 'test_user'
 end
 
 append_if_no_line 'missing_file fail' do

--- a/test/fixtures/cookbooks/test/recipes/replace_or_add_missing_file.rb
+++ b/test/fixtures/cookbooks/test/recipes/replace_or_add_missing_file.rb
@@ -2,6 +2,8 @@
 # Test replace_or_add with a missing file.
 #
 
+user 'test_user'
+
 replace_or_add 'missing_file fail' do
   path '/tmp/missingfile'
   pattern 'Does not match'
@@ -20,6 +22,14 @@ replace_or_add 'missing_file matches_pattern' do
   path '/tmp/missingfile_matches_pattern'
   pattern '^add this'
   line 'add this line'
+end
+
+replace_or_add 'missing_file_owner' do
+  path '/tmp/missingfile_owner'
+  pattern 'Does not match'
+  line 'Owned by test_user'
+  owner 'test_user'
+  group 'test_user'
 end
 
 replace_or_add 'missing_file replace_only' do

--- a/test/integration/append_if_no_line/inspec/controls/append_if_no_line_empty.rb
+++ b/test/integration/append_if_no_line/inspec/controls/append_if_no_line_empty.rb
@@ -21,6 +21,17 @@ control 'append_if_no_line_empty' do
     its('size_lines') { should eq 1 }
   end
 
+  describe file('/tmp/missing_create_owner') do
+    it { should exist }
+    its('content') { should match /^Owned by test_user$/ }
+    its('owner') { should cmp 'test_user' }
+    its('group') { should cmp 'test_user' }
+  end
+  describe file_ext('/tmp/missing_create_owner') do
+    it { should have_correct_eol }
+    its('size_lines') { should eq 1 }
+  end
+
   describe file('/tmp/missing_fail') do
     it { should_not exist }
   end

--- a/test/integration/replace_or_add/controls/replace_or_add_missing_file.rb
+++ b/test/integration/replace_or_add/controls/replace_or_add_missing_file.rb
@@ -31,4 +31,17 @@ control 'replace_or_add_missing_file' do
     it { should have_correct_eol }
     its('size_lines') { should eq 1 }
   end
+
+  describe file('/tmp/missingfile_owner') do
+    it { should exist }
+    its('owner') { should cmp 'test_user' }
+    its('group') { should cmp 'test_user' }
+  end
+  describe matches('/tmp/missingfile_owner', /^Owned by test_user$/) do
+    its('count') { should eq 1 }
+  end
+  describe file_ext('/tmp/missingfile_owner') do
+    it { should have_correct_eol }
+    its('size_lines') { should eq 1 }
+  end
 end


### PR DESCRIPTION
# Description

Add `owner` and `group` properties to resources that will create missing files.

## Issues Resolved

N/a

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
