### PR TITLE
Add mode property to the `append_if_no_line` and `replace_or_add` resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- Add `mode` property to the `append_if_no_line` and `replace_or_add` resources
+- Add corresponding tests
+
 ## 4.2.0 - *2021-08-23*
 
 - Add `owner` and `group` properties to the `append_if_no_line` and `replace_or_add` resources

--- a/documentation/resources/append_if_no_line.md
+++ b/documentation/resources/append_if_no_line.md
@@ -17,6 +17,7 @@
 | backup         | Backup before changing            | Boolean, Integer | default false                           |
 | owner          | Set the `owner` of the file       | String           | no default                              |
 | group          | Set the `group` of the file       | String           | no default                              |
+| mode           | Set the `mode` of the file        | String, Integer  | no default                              |
 
 ## Example Usage
 

--- a/documentation/resources/replace_or_add.md
+++ b/documentation/resources/replace_or_add.md
@@ -20,6 +20,7 @@
 | backup            | Backup before changing                   | Boolean, Integer             | default false                           |
 | owner             | Set the `owner` of the file              | String                       | no default                              |
 | group             | Set the `group` of the file              | String                       | no default                              |
+| mode              | Set the `mode` of the file               | String, Integer              | no default                              |
 
 ## Example Usage
 

--- a/resources/append_if_no_line.rb
+++ b/resources/append_if_no_line.rb
@@ -3,6 +3,7 @@ property :eol, String
 property :group, String
 property :ignore_missing, [true, false], default: true
 property :line, String
+property :mode, [String, Integer]
 property :owner, String
 property :path, String
 
@@ -24,6 +25,7 @@ action :edit do
     content((current + [add_line + eol]).join(eol))
     owner new_resource.owner
     group new_resource.group
+    mode new_resource.mode
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { ::File.exist?(new_resource.path) && !current.grep(regex).empty? }

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -3,6 +3,7 @@ property :eol, String
 property :group, String
 property :ignore_missing, [true, false], default: true
 property :line, String
+property :mode, [String, Integer]
 property :owner, String
 property :path, String
 property :pattern, [String, Regexp]
@@ -44,6 +45,7 @@ action :edit do
     content new.join(eol)
     owner new_resource.owner
     group new_resource.group
+    mode new_resource.mode
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { new == current }

--- a/test/fixtures/cookbooks/test/recipes/append_if_no_line_empty.rb
+++ b/test/fixtures/cookbooks/test/recipes/append_if_no_line_empty.rb
@@ -16,11 +16,12 @@ append_if_no_line 'missing_file' do
   line 'added line'
 end
 
-append_if_no_line 'missing_file with owner and group' do
+append_if_no_line 'missing_file with owner, group, mode' do
   path '/tmp/missing_create_owner'
   line 'Owned by test_user'
   owner 'test_user'
   group 'test_user'
+  mode '0600'
 end
 
 append_if_no_line 'missing_file fail' do

--- a/test/fixtures/cookbooks/test/recipes/replace_or_add_missing_file.rb
+++ b/test/fixtures/cookbooks/test/recipes/replace_or_add_missing_file.rb
@@ -30,6 +30,7 @@ replace_or_add 'missing_file_owner' do
   line 'Owned by test_user'
   owner 'test_user'
   group 'test_user'
+  mode '0600'
 end
 
 replace_or_add 'missing_file replace_only' do

--- a/test/integration/append_if_no_line/inspec/controls/append_if_no_line_empty.rb
+++ b/test/integration/append_if_no_line/inspec/controls/append_if_no_line_empty.rb
@@ -26,6 +26,7 @@ control 'append_if_no_line_empty' do
     its('content') { should match /^Owned by test_user$/ }
     its('owner') { should cmp 'test_user' }
     its('group') { should cmp 'test_user' }
+    its('mode') { should cmp '0600' }
   end
   describe file_ext('/tmp/missing_create_owner') do
     it { should have_correct_eol }

--- a/test/integration/replace_or_add/controls/replace_or_add_missing_file.rb
+++ b/test/integration/replace_or_add/controls/replace_or_add_missing_file.rb
@@ -36,6 +36,7 @@ control 'replace_or_add_missing_file' do
     it { should exist }
     its('owner') { should cmp 'test_user' }
     its('group') { should cmp 'test_user' }
+    its('mode') { should cmp '0600' }
   end
   describe matches('/tmp/missingfile_owner', /^Owned by test_user$/) do
     its('count') { should eq 1 }


### PR DESCRIPTION
# Description

Add mode property to the `append_if_no_line` and `replace_or_add` resources
This should have been done in my other pr but I overlooked it.

## Issues Resolved

N/a

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
