### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 
 - resolved cookstyle error: resources/delete_from_list.rb:32:1 refactor: `Chef/Modernize/ClassEvalActionClass`
+
 ## 4.3.0 - *2021-08-24*
 
 - Add `mode` property to the `append_if_no_line` and `replace_or_add` resources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+- resolved cookstyle error: resources/delete_from_list.rb:32:1 refactor: `Chef/Modernize/ClassEvalActionClass`
 ## 4.3.0 - *2021-08-24*
 
 - Add `mode` property to the `append_if_no_line` and `replace_or_add` resources

--- a/resources/delete_from_list.rb
+++ b/resources/delete_from_list.rb
@@ -29,7 +29,7 @@ action :edit do
   end
 end
 
-action_class.class_eval do
+action_class do
   include Line::Helper
   include Line::ListHelper
 end


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.23.0 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/delete_from_list.rb

 - 32:1 refactor: `Chef/Modernize/ClassEvalActionClass` - In Chef Infra Client 12.9 and later it is no longer necessary to call the class_eval method on the action class block. (https://docs.chef.io/workstation/cookstyle/chef_modernize_classevalactionclass)