### PR TITLE
WIP containerEtcHosts: Investigate a reported problem with updating /etc/…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+Try to reproduce error
+
 ## 4.5.16 - *2023-10-31*
 
 ## 4.5.15 - *2023-09-28*

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -65,6 +65,7 @@ suites:
   - name: replace_or_add
     run_list:
       - recipe[test::replace_or_add_add_a_line_matching_pattern]
+      - recipe[test::replace_or_add_add_a_line_etchosts]
       - recipe[test::replace_or_add_change_line_eof]
       - recipe[test::replace_or_add_duplicate]
       - recipe[test::replace_or_add_missing_file]

--- a/test/fixtures/cookbooks/test/recipes/replace_or_add_add_a_line_etchosts.rb
+++ b/test/fixtures/cookbooks/test/recipes/replace_or_add_add_a_line_etchosts.rb
@@ -1,0 +1,9 @@
+#
+# Add a line that exactly matches the specified pattern.
+#
+
+replace_or_add 'add_a_line_matching_pattern_etchosts' do
+  path '/etc/hosts'
+  pattern '# Add etchosts line'
+  line '# Add etchosts line'
+end

--- a/test/integration/replace_or_add/controls/replace_or_add_add_a_line_etchosts.rb
+++ b/test/integration/replace_or_add/controls/replace_or_add_add_a_line_etchosts.rb
@@ -1,0 +1,12 @@
+#
+# Add a line matching pattern
+#
+
+control 'replace_or_add_add_a_line_etc_hosts' do
+  describe file('/etc/hosts') do
+    it { should exist }
+  end
+  describe matches('/etc/hosts', /^# Add another line$/) do
+    its('count') { should eq 1 }
+  end
+end


### PR DESCRIPTION
…hosts

When /etc/hosts is in a container the file replace option is supposed to turn off the atomic update feature.  It has been reported the the atomic update feature may be being left on causing replace_or_add to fail.

# Description

See if the problem is reproducible.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
