### PR TITLE
chore(style): Cookstyle Fixes

### DIFF
--- a/libraries/after_filter.rb
+++ b/libraries/after_filter.rb
@@ -27,7 +27,7 @@ module Line
       # args[3] options allowed - safe
       #
       # returns array with inserted lines
-      match_pattern = verify_kind(args[0], Regexp)
+      match_pattern = verify_kind(args.first, Regexp)
       insert_array = prepare_insert_lines(args[1])
       select_match = verify_one_of(args[2], [nil, :each, 'each', :first, 'first', :last, 'last']) || :each
       options(args[3], safe: [true, false])

--- a/libraries/before_filter.rb
+++ b/libraries/before_filter.rb
@@ -33,7 +33,7 @@ module Line
       # args[3] options allowed - safe
       #
       # returns array with inserted lines
-      match_pattern = verify_kind(args[0], Regexp)
+      match_pattern = verify_kind(args.first, Regexp)
       insert_array = prepare_insert_lines(args[1])
       select_match = verify_one_of(args[2], [nil, :each, 'each', :first, 'first', :last, 'last']) || :each
       options(args[3], safe: [true, false])

--- a/libraries/between.rb
+++ b/libraries/between.rb
@@ -9,7 +9,7 @@ module Line
       # args[2] is a string or an array of lines to insert after the matched lines
       #
       # returns array with inserted lines
-      first_pattern = verify_kind(args[0], Regexp)
+      first_pattern = verify_kind(args.first, Regexp)
       second_pattern = verify_kind(args[1], Regexp)
       insert_array = prepare_insert_lines(args[2])
 

--- a/libraries/comment_filter.rb
+++ b/libraries/comment_filter.rb
@@ -25,7 +25,7 @@ module Line
       # args[2] Space between comment string and the real line
       #
       # returns array with inserted lines
-      match_pattern = verify_kind(args[0], Regexp)
+      match_pattern = verify_kind(args.first, Regexp)
       @comment_str = verify_kind(args[1], [String, NilClass]) || '#'
       @comment_space = verify_kind(args[2], [String, NilClass]) || ' '
 

--- a/libraries/delete_between.rb
+++ b/libraries/delete_between.rb
@@ -27,7 +27,7 @@ module Line
       # args[3] is a symbol. Include the start and end lines in the delete match. Default is :exclude. Other options are :first, :include, :last
       #
       # returns array with deleted lines
-      first_pattern = verify_kind(args[0], Regexp)
+      first_pattern = verify_kind(args.first, Regexp)
       second_pattern = verify_kind(args[1], Regexp)
       delete_pattern = verify_kind(args[2], Regexp)
       ends = verify_one_of(args[3], [nil, :exclude, :first, :include, :last]) || :exclude

--- a/libraries/filter_helper.rb
+++ b/libraries/filter_helper.rb
@@ -54,10 +54,9 @@ module Line
     attr_accessor :eol
 
     def expand(lines)
-      new_lines = []
-      lines.each do |line|
+      new_lines = lines.map do |line|
         # NOTE: - want to do *lines to add them instead adding an array
-        new_lines.push line.class == Replacement ? line.insert : line
+        line.class == Replacement ? line.insert : line
       end
       new_lines.compact.flatten # add the lines better so we don't need this
     end

--- a/libraries/list_helper.rb
+++ b/libraries/list_helper.rb
@@ -27,10 +27,10 @@ module Line
         line = line.dup
         next unless line =~ line_select
         list_end = line.rindex(/#{ends_with}/) || 0
-        seperator = line =~ /#{new_resource.pattern}.*\S.*#{ends_with}/ ? new_resource.delim[0] : ''
+        seperator = line =~ /#{new_resource.pattern}.*\S.*#{ends_with}/ ? new_resource.delim.first : ''
         case new_resource.delim.count
         when 1
-          next if line =~ /(#{regexdelim[0]}|#{new_resource.pattern})\s*#{new_resource.entry}\s*(#{regexdelim[0]}|#{ends_with})/
+          next if line =~ /(#{regexdelim.first}|#{new_resource.pattern})\s*#{new_resource.entry}\s*(#{regexdelim.first}|#{ends_with})/
           line = line.insert(list_end, "#{seperator}#{new_resource.entry}")
         when 2
           next if line =~ /#{regexdelim[1]}#{new_resource.entry}\s*#{regexdelim[1]}/
@@ -57,24 +57,24 @@ module Line
         case new_resource.delim.count
         when 1
           case line
-          when /#{regexdelim[0]}\s*#{new_resource.entry}\s*(#{regexdelim[0]}|#{ends_with})/
+          when /#{regexdelim.first}\s*#{new_resource.entry}\s*(#{regexdelim.first}|#{ends_with})/
             prefix, list, suffix = line_parts(line, pattern, ends_with)
-            list = list.sub(/(#{regexdelim[0]})*\s*#{new_resource.entry}(\s*#{regexdelim[0]}\s*|\s*\z)/, new_resource.delim[0])
+            list = list.sub(/(#{regexdelim.first})*\s*#{new_resource.entry}(\s*#{regexdelim.first}\s*|\s*\z)/, new_resource.delim.first)
             line = prefix + list + suffix
             # delete any trailing delimeters
-            line = line.sub(/\s*#{regexdelim[0]}*\s*(#{ends_with})\s*$/, '\1') # want to delete between last entry and ends_with
-          when /#{new_resource.entry}\s*(#{regexdelim[0]}|#{ends_with})/
-            line = line.sub(/#{new_resource.entry}(#{regexdelim[0]})*/, '')
+            line = line.sub(/\s*#{regexdelim.first}*\s*(#{ends_with})\s*$/, '\1') # want to delete between last entry and ends_with
+          when /#{new_resource.entry}\s*(#{regexdelim.first}|#{ends_with})/
+            line = line.sub(/#{new_resource.entry}(#{regexdelim.first})*/, '')
           end
         when 2
           case line
           when /#{regexdelim[1]}#{new_resource.entry}#{regexdelim[1]}/
-            line = line.sub(/(#{regexdelim[0]})*\s*#{regexdelim[1]}#{new_resource.entry}#{regexdelim[1]}(#{regexdelim[0]})*/, '')
+            line = line.sub(/(#{regexdelim.first})*\s*#{regexdelim[1]}#{new_resource.entry}#{regexdelim[1]}(#{regexdelim.first})*/, '')
           end
         when 3
           case line
           when /#{regexdelim[1]}#{new_resource.entry}#{regexdelim[2]}/
-            line = line.sub(/(#{regexdelim[0]})*\s*#{regexdelim[1]}#{new_resource.entry}#{regexdelim[2]}(#{regexdelim[0]})*/, '')
+            line = line.sub(/(#{regexdelim.first})*\s*#{regexdelim[1]}#{new_resource.entry}#{regexdelim[2]}(#{regexdelim.first})*/, '')
           end
         end
         new[-1] = line

--- a/libraries/missing_filter.rb
+++ b/libraries/missing_filter.rb
@@ -25,7 +25,7 @@ module Line
       # args[1] :after or :before
       #
       # returns array with inserted lines
-      insert_array = prepare_insert_lines(args[0])
+      insert_array = prepare_insert_lines(args.first)
       add_point = verify_one_of(args[1], [nil, :after, 'after', :before, 'before']) || :after
 
       case add_point
@@ -35,8 +35,8 @@ module Line
         current[current.size] = Replacement.new(current[current.size], insert_lines, rep)
       when :before
         insert_lines = missing_lines_between(current, -1, current.size + 1, insert_array)
-        rep = current[0] ? :before : :replace
-        current[0] = Replacement.new(current[0], insert_lines, rep)
+        rep = current.first ? :before : :replace
+        current[0] = Replacement.new(current.first, insert_lines, rep)
       end
       expand(current)
     end

--- a/libraries/replace_between.rb
+++ b/libraries/replace_between.rb
@@ -28,7 +28,7 @@ module Line
       # args[4] options.
       #
       # returns array with replaced lines
-      start_pattern = verify_kind(args[0], Regexp)
+      start_pattern = verify_kind(args.first, Regexp)
       end_pattern = verify_kind(args[1], Regexp)
       insert_array = prepare_insert_lines(args[2])
       ends = verify_all_of(args[3], [nil, :exclude, :first, :include, :last, :next]) || :exclude

--- a/libraries/replace_filter.rb
+++ b/libraries/replace_filter.rb
@@ -27,7 +27,7 @@ module Line
       #
       # returns array with inserted lines
       #
-      match_pattern = verify_kind(args[0], Regexp)
+      match_pattern = verify_kind(args.first, Regexp)
       insert_array = prepare_insert_lines(args[1])
       options(args[2], safe: [true, false])
 

--- a/libraries/stanza_filter.rb
+++ b/libraries/stanza_filter.rb
@@ -37,7 +37,7 @@ module Line
       # args[2] keyword style option
       # Comment lines will be ignored
       #
-      @stanza_name = verify_kind(args[0], String)
+      @stanza_name = verify_kind(args.first, String)
       @settings = verify_kind(args[1], Hash) # A hash of keywords and values
       @key_style = (verify_one_of(args[2], [nil, :equal, 'equal', :value, 'value']) || :equal).to_sym
 

--- a/libraries/substitute_filter.rb
+++ b/libraries/substitute_filter.rb
@@ -30,7 +30,7 @@ module Line
       # error condition - If the substitute string will match a line after replacement
       #  it is possible for the file size to increase after every converge. Use force
       # to ignore the possible error.
-      match_pattern = verify_kind(args[0], Regexp)
+      match_pattern = verify_kind(args.first, Regexp)
       sub_pattern = verify_kind(args[1], [Regexp]) || match_pattern
       substitute_str = verify_kind(args[2], [NilClass, String, Hash]) # String or Hash
       options(args[3], safe: [true, false])

--- a/resources/add_to_list.rb
+++ b/resources/add_to_list.rb
@@ -22,7 +22,7 @@ action :edit do
   new = insert_list_entry(current)
 
   # eol on last line
-  new[-1] += eol unless new[-1].to_s.empty?
+  new.last += eol unless new.last.to_s.empty?
 
   file new_resource.path do
     content new.join(eol)

--- a/resources/delete_from_list.rb
+++ b/resources/delete_from_list.rb
@@ -20,7 +20,7 @@ action :edit do
   current = target_current_lines
   new = delete_list_entry(current)
 
-  new[-1] += eol unless new[-1].to_s.empty?
+  new.last += eol unless new.last.to_s.empty?
   file new_resource.path do
     content new.join(eol)
     backup new_resource.backup

--- a/resources/delete_lines.rb
+++ b/resources/delete_lines.rb
@@ -21,7 +21,7 @@ action :edit do
   new = current.reject { |l| l =~ regex }
 
   # Last line terminator
-  new[-1] += eol unless new[-1].to_s.empty?
+  new.last += eol unless new.last.to_s.empty?
 
   file new_resource.path do
     content new.join(eol)

--- a/resources/filter_lines.rb
+++ b/resources/filter_lines.rb
@@ -63,8 +63,8 @@ action :edit do
   end
 
   # eol on last line
-  @new[-1] += eol unless @new[-1].to_s.empty?
-  current[-1] += eol unless current[-1].to_s.empty?
+  @new.last += eol unless @new.last.to_s.empty?
+  current.last += eol unless current.last.to_s.empty?
   new = @new
 
   file new_resource.path do

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -39,7 +39,7 @@ action :edit do
   new << add_line unless found || new_resource.replace_only
 
   # Last line terminator
-  new[-1] += eol unless new[-1].to_s.empty?
+  new.last += eol unless new.last.to_s.empty?
 
   file new_resource.path do
     content new.join(eol)

--- a/spec/unit/library/filter/stanza_spec.rb
+++ b/spec/unit/library/filter/stanza_spec.rb
@@ -132,16 +132,16 @@ describe 'stanza method' do
   end
 
   it 'should allow certain characters in a stanza name' do
-    expect('stanzakey' =~ @filt.key_value_regex).to be_truthy()
-    expect('/stanzakey@' =~ @filt.key_value_regex).to be_truthy()
-    expect('/abcde1234-_.%@' =~ @filt.key_value_regex).to be_truthy()
+    expect('stanzakey' =~ @filt.key_value_regex).to be_truthy
+    expect('/stanzakey@' =~ @filt.key_value_regex).to be_truthy
+    expect('/abcde1234-_.%@' =~ @filt.key_value_regex).to be_truthy
   end
 
   it 'should not allow leading and trailing blanks in a stanza name' do
-    expect(' stanzakey ' =~ @filt.key_value_regex).to be_falsy()
+    expect(' stanzakey ' =~ @filt.key_value_regex).to be_falsy
   end
 
   it 'should only allow character in the name pattern in a stanza name' do
-    expect('stanza key' =~ @filt.key_value_regex).to be_falsy()
+    expect('stanza key' =~ @filt.key_value_regex).to be_falsy
   end
 end


### PR DESCRIPTION
# Cookstyle Automated Changes

This pull request applies automatic Cookstyle fixes to ensure code quality and consistency.

## Changes Made

* **libraries/after_filter.rb**: Style/ArrayFirstLast
* **libraries/before_filter.rb**: Style/ArrayFirstLast
* **libraries/between.rb**: Style/ArrayFirstLast
* **libraries/comment_filter.rb**: Style/ArrayFirstLast
* **libraries/delete_between.rb**: Style/ArrayFirstLast
* **libraries/filter_helper.rb**: Style/MapIntoArray
* **libraries/list_helper.rb**: Style/ArrayFirstLast
* **libraries/missing_filter.rb**: Style/ArrayFirstLast
* **libraries/replace_between.rb**: Style/ArrayFirstLast
* **libraries/replace_filter.rb**: Style/ArrayFirstLast
* **libraries/stanza_filter.rb**: Style/ArrayFirstLast
* **libraries/substitute_filter.rb**: Style/ArrayFirstLast
* **resources/add_to_list.rb**: Style/ArrayFirstLast
* **resources/delete_from_list.rb**: Style/ArrayFirstLast
* **resources/delete_lines.rb**: Style/ArrayFirstLast
* **resources/filter_lines.rb**: Style/ArrayFirstLast
* **resources/replace_or_add.rb**: Style/ArrayFirstLast
* **spec/unit/library/filter/stanza_spec.rb**: Style/MethodCallWithoutArgsParentheses
### Summary

* Total offenses detected: 45
* Files with issues: 18

*This issue was automatically generated by the [GitHub Cookstyle Runner](https://github.com/damacus/github-cookstyle-runner).*
