### PR TITLE
fix: Remove debug lines from Chef run

### DIFF
--- a/libraries/replace_between.rb
+++ b/libraries/replace_between.rb
@@ -52,14 +52,6 @@ module Line
 
       start_line = first_matches.first
       end_line = match_limits(ends, [:next]) ? next_match_after(start_line, second_matches) : second_matches.last
-      puts
-      puts "START #{start_line}"
-      puts "END #{end_line}"
-      puts "ENDS #{ends}"
-      puts "Current #{current}"
-      puts "Start Pattern #{start_pattern}"
-      puts "END Pattern #{end_pattern}"
-      puts "SMATCH #{second_matches}"
 
       if start_line && end_line && start_line <= end_line
         replace_start = match_limits(ends, [:first, :include]) ? start_line : start_line + 1
@@ -69,7 +61,6 @@ module Line
         end
         current[replace_start] = Replacement.new(current[replace_start], insert_array, :replace)
       end
-      puts "NEW #{expand(current)}"
       expand(current)
     end
   end


### PR DESCRIPTION
fix: remove debug lines

None of the filters have `puts`, neither should `replace_between` have them. This makes the chef-client output harder to read.

# Description

Have a less verbose output

## Issues Resolved

Readability of a chef-client run

## Check List

- [x] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
  - **Required**: This triggers our automated CHANGELOG and release pipeline (release-please)
  - **Without conventional commits, your changes cannot be released**
  - Examples: `fix: resolve bug in resource`, `feat: add new property`, `docs: update README`
- [x] New functionality includes testing
- [x] New functionality has been documented in the README if applicable

## ⚠️ Important: Automated Release Workflow

**DO NOT manually edit these files:**

- ❌ `metadata.rb` version - Managed by release-please
- ❌ `CHANGELOG.md` - Auto-generated from conventional commits
- ❌ Version tags - Created automatically on release

**The release process:**

1. Merge PR with conventional commits → release-please creates a release PR
2. Merge release PR → automatic version bump, CHANGELOG update, and Supermarket publish
3. Your changes are released! 🎉

**Need help?** See [Conventional Commits guide](https://www.conventionalcommits.org/)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line/284)
<!-- Reviewable:end -->
