### PR TITLE
feat: expose manage_symlink_source and release slack secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,5 @@ jobs:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}
       supermarket_key: ${{ secrets.CHEF_SUPERMARKET_KEY }}
+      slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+      slack_channel_id: ${{ secrets.SLACK_CHANNEL_ID }}

--- a/documentation/resources/add_to_list.md
+++ b/documentation/resources/add_to_list.md
@@ -18,6 +18,7 @@
 | ignore_missing | Don't fail if the file is missing  | true or false                | Default is true                             |
 | eol            | Alternate line end characters      | String                       | default `\n` on unix, `\r\n` on windows     |
 | backup         | Backup before changing             | Boolean, Integer             | default false                               |
+| manage_symlink_source | Pass through Chef's symlink-source handling; setting it explicitly also suppresses Chef's symlink warning | true or false | no default |
 
 ## Example Usage
 
@@ -74,3 +75,5 @@ Pattern -    'multi = "'
 Add this -   entry "425"
 Output -     multi = "([425])"
 ```
+
+If `manage_symlink_source` is set to `true`, Chef manages the symlink source file. If it is set to `false`, Chef disables symlink-source handling and may require the symlink to be removed before writing.

--- a/documentation/resources/append_if_no_line.md
+++ b/documentation/resources/append_if_no_line.md
@@ -18,6 +18,7 @@
 | owner          | Set the `owner` of the file       | String           | no default                              |
 | group          | Set the `group` of the file       | String           | no default                              |
 | mode           | Set the `mode` of the file        | String, Integer  | no default                              |
+| manage_symlink_source | Pass through Chef's symlink-source handling; setting it explicitly also suppresses Chef's symlink warning | true or false | no default |
 
 ## Example Usage
 
@@ -31,3 +32,5 @@ end
 ## Notes
 
 This resource is intended to match the whole line **exactly**. That means if the file contains `this is my line` (trailing whitespace) and you've specified `line "this is my line"`, another line will be added. You may want to use `replace_or_add` instead, depending on your use case.
+
+If `manage_symlink_source` is set to `true`, Chef manages the symlink source file. If it is set to `false`, Chef disables symlink-source handling and may require the symlink to be removed before writing.

--- a/documentation/resources/delete_from_list.md
+++ b/documentation/resources/delete_from_list.md
@@ -18,6 +18,7 @@
 | ignore_missing | Don't fail if the file is missing  | true or false                | Default is true                             |
 | eol            | Alternate line end characters      | String                       | default `\n` on unix, `\r\n` on windows     |
 | backup         | Backup before changing             | Boolean, Integer             | default false                               |
+| manage_symlink_source | Pass through Chef's symlink-source handling; setting it explicitly also suppresses Chef's symlink warning | true or false | no default |
 
 ## Example Usage
 
@@ -33,3 +34,5 @@ end
 ## Notes
 
 Delimiters are defined and used as in [add_to_list](https://github.com/sous-chefs/line/blob/master/documentation/resources/add_to_list.md).
+
+If `manage_symlink_source` is set to `true`, Chef manages the symlink source file. If it is set to `false`, Chef disables symlink-source handling and may require the symlink to be removed before writing.

--- a/documentation/resources/delete_lines.md
+++ b/documentation/resources/delete_lines.md
@@ -15,6 +15,7 @@
 | ignore_missing | Don't fail if the file is missing  | true or false                | Default is true                         |
 | eol            | Alternate line end characters      | String                       | default `\n` on unix, `\r\n` on windows |
 | backup         | Backup before changing             | Boolean, Integer             | default false                           |
+| manage_symlink_source | Pass through Chef's symlink-source handling; setting it explicitly also suppresses Chef's symlink warning | true or false | no default |
 
 ## Example Usage
 
@@ -43,3 +44,5 @@ end
 ## Notes
 
 Removes lines based on a string or regex.
+
+If `manage_symlink_source` is set to `true`, Chef manages the symlink source file. If it is set to `false`, Chef disables symlink-source handling and may require the symlink to be removed before writing.

--- a/documentation/resources/filter_lines.md
+++ b/documentation/resources/filter_lines.md
@@ -15,6 +15,7 @@
 | ignore_missing | Don't fail if the file is missing                                                                                          | true or false          | Default is true                     |
 | eol            | Alternate line end characters                                                                                              | String                 | default \n on unix, \r\n on windows |
 | backup         | Backup before changing                                                                                                     | Boolean, Integer       | default false                       |
+| manage_symlink_source | Pass through Chef's symlink-source handling; setting it explicitly also suppresses Chef's symlink warning | true or false | no default |
 | safe           | Verify that the inserts don't cause a file to grow with each converge. The filter must support safe mode for this to work. | Boolean                | default true                        |
 | sensitive      | Print the file changes                                                                                                     | Boolean                | default false                       |
 
@@ -66,6 +67,7 @@ The filter_lines resource passes the contents of the path file in an array of li
 The filter should return an array of lines. The output array will be written to the file or passed to the next filter.
 The built in filters are usable examples of what can be done with a filter, please write your own when you have specific needs.
 The built in filters all take an array of positional arguments.
+If `manage_symlink_source` is set to `true`, Chef manages the symlink source file. If it is set to `false`, Chef disables symlink-source handling and may require the symlink to be removed before writing.
 
 ## Filter Options
 

--- a/documentation/resources/replace_or_add.md
+++ b/documentation/resources/replace_or_add.md
@@ -21,6 +21,7 @@
 | owner             | Set the `owner` of the file              | String                       | no default                              |
 | group             | Set the `group` of the file              | String                       | no default                              |
 | mode              | Set the `mode` of the file               | String, Integer              | no default                              |
+| manage_symlink_source | Pass through Chef's symlink-source handling; setting it explicitly also suppresses Chef's symlink warning | true or false | no default |
 
 ## Example Usage
 
@@ -40,3 +41,5 @@ replace_or_add "change the love, don't add more" do
   replace_only true
 end
 ```
+
+If `manage_symlink_source` is set to `true`, Chef manages the symlink source file. If it is set to `false`, Chef disables symlink-source handling and may require the symlink to be removed before writing.

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -72,3 +72,4 @@ suites:
       - recipe[test::replace_or_add_duplicate]
       - recipe[test::replace_or_add_missing_file]
       - recipe[test::replace_or_add_replace_only]
+      - recipe[test::replace_or_add_manage_symlink_source]

--- a/resources/add_to_list.rb
+++ b/resources/add_to_list.rb
@@ -4,6 +4,7 @@ property :ends_with, String
 property :entry, String
 property :eol, String
 property :ignore_missing, [true, false], default: true
+property :manage_symlink_source, [true, false]
 property :path, String
 property :pattern, [String, Regexp]
 
@@ -17,6 +18,7 @@ action :edit do
   eol = default_eol
   backup_if_true
   current = target_current_lines
+  manage_symlink_source_explicit = property_is_set?(:manage_symlink_source)
 
   # insert
   new = insert_list_entry(current)
@@ -26,6 +28,7 @@ action :edit do
 
   file new_resource.path do
     content new.join(eol)
+    manage_symlink_source new_resource.manage_symlink_source if manage_symlink_source_explicit
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { new == current }

--- a/resources/append_if_no_line.rb
+++ b/resources/append_if_no_line.rb
@@ -3,6 +3,7 @@ property :eol, String
 property :group, String
 property :ignore_missing, [true, false], default: true
 property :line, String
+property :manage_symlink_source, [true, false]
 property :mode, [String, Integer]
 property :owner, String
 property :path, String
@@ -20,12 +21,14 @@ action :edit do
   string = Regexp.escape(add_line)
   regex = /^#{string}$/
   current = target_current_lines
+  manage_symlink_source_explicit = property_is_set?(:manage_symlink_source)
 
   file new_resource.path do
     content((current + [add_line + eol]).join(eol))
     owner new_resource.owner
     group new_resource.group
     mode new_resource.mode
+    manage_symlink_source new_resource.manage_symlink_source if manage_symlink_source_explicit
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { ::File.exist?(new_resource.path) && !current.grep(regex).empty? }

--- a/resources/delete_from_list.rb
+++ b/resources/delete_from_list.rb
@@ -4,6 +4,7 @@ property :entry, String
 property :ends_with, String
 property :eol, String
 property :ignore_missing, [true, false], default: true
+property :manage_symlink_source, [true, false]
 property :path, String
 property :pattern, [String, Regexp]
 
@@ -19,10 +20,12 @@ action :edit do
   backup_if_true
   current = target_current_lines
   new = delete_list_entry(current)
+  manage_symlink_source_explicit = property_is_set?(:manage_symlink_source)
 
   terminate_last_line(new, eol)
   file new_resource.path do
     content new.join(eol)
+    manage_symlink_source new_resource.manage_symlink_source if manage_symlink_source_explicit
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { new == current }

--- a/resources/delete_lines.rb
+++ b/resources/delete_lines.rb
@@ -1,6 +1,7 @@
 property :backup, [true, false, Integer], default: false
 property :eol, String
 property :ignore_missing, [true, false], default: true
+property :manage_symlink_source, [true, false]
 property :path, String
 property :pattern, [String, Regexp]
 
@@ -16,6 +17,7 @@ action :edit do
   backup_if_true
   regex = new_resource.pattern.is_a?(String) ? /#{new_resource.pattern}/ : new_resource.pattern
   current = target_current_lines
+  manage_symlink_source_explicit = property_is_set?(:manage_symlink_source)
 
   # remove lines
   new = current.reject { |l| l =~ regex }
@@ -25,6 +27,7 @@ action :edit do
 
   file new_resource.path do
     content new.join(eol)
+    manage_symlink_source new_resource.manage_symlink_source if manage_symlink_source_explicit
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { new == current }

--- a/resources/filter_lines.rb
+++ b/resources/filter_lines.rb
@@ -19,6 +19,7 @@ property :backup, [true, false, Integer], default: false
 property :eol, String
 property :filters, [Array, Hash, Method, Proc], required: true
 property :ignore_missing, [true, false], default: true
+property :manage_symlink_source, [true, false]
 property :path, String, name_property: true
 property :safe, [true, false], default: true
 
@@ -34,6 +35,7 @@ action :edit do
 
   current = ::File.exist?(new_resource.path) ? ::File.binread(new_resource.path).split(eol) : []
   @new = current.clone
+  manage_symlink_source_explicit = property_is_set?(:manage_symlink_source)
 
   # Proc or Method
   # if new_resource.filter.is_a?(Method) || new_resource.filter.is_a?(Proc)
@@ -69,6 +71,7 @@ action :edit do
 
   file new_resource.path do
     content new.join(eol)
+    manage_symlink_source new_resource.manage_symlink_source if manage_symlink_source_explicit
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { new == current }

--- a/resources/replace_or_add.rb
+++ b/resources/replace_or_add.rb
@@ -3,6 +3,7 @@ property :eol, String
 property :group, String
 property :ignore_missing, [true, false], default: true
 property :line, String
+property :manage_symlink_source, [true, false]
 property :mode, [String, Integer]
 property :owner, String
 property :path, String
@@ -24,6 +25,7 @@ action :edit do
   regex = new_resource.pattern.is_a?(String) ? /#{new_resource.pattern}/ : new_resource.pattern
   new = []
   current = target_current_lines
+  manage_symlink_source_explicit = property_is_set?(:manage_symlink_source)
 
   # replace
   current.each do |line|
@@ -46,6 +48,7 @@ action :edit do
     owner new_resource.owner
     group new_resource.group
     mode new_resource.mode
+    manage_symlink_source new_resource.manage_symlink_source if manage_symlink_source_explicit
     backup new_resource.backup
     sensitive new_resource.sensitive
     not_if { new == current }

--- a/test/fixtures/cookbooks/test/recipes/replace_or_add_manage_symlink_source.rb
+++ b/test/fixtures/cookbooks/test/recipes/replace_or_add_manage_symlink_source.rb
@@ -1,0 +1,27 @@
+file '/tmp/replace_or_add_symlink_target' do
+  content "keep me\n"
+  action :create_if_missing
+end
+
+link '/tmp/replace_or_add_symlink' do
+  to '/tmp/replace_or_add_symlink_target'
+end
+
+replace_or_add 'replace_or_add_manage_symlink_source_true' do
+  path '/tmp/replace_or_add_symlink'
+  pattern '^keep me$'
+  line 'updated through target'
+  manage_symlink_source true
+end
+
+file '/tmp/replace_or_add_manage_symlink_source_false' do
+  content "before explicit false\n"
+  action :create_if_missing
+end
+
+replace_or_add 'replace_or_add_manage_symlink_source_false' do
+  path '/tmp/replace_or_add_manage_symlink_source_false'
+  pattern '^before explicit false$'
+  line 'updated with explicit false'
+  manage_symlink_source false
+end

--- a/test/integration/replace_or_add/controls/replace_or_add_manage_symlink_source.rb
+++ b/test/integration/replace_or_add/controls/replace_or_add_manage_symlink_source.rb
@@ -1,0 +1,20 @@
+control 'replace_or_add_manage_symlink_source' do
+  describe command('test -L /tmp/replace_or_add_symlink') do
+    its('exit_status') { should eq 0 }
+  end
+
+  describe file('/tmp/replace_or_add_symlink') do
+    it { should exist }
+    its('content') { should match(/^updated through target$/) }
+  end
+
+  describe file('/tmp/replace_or_add_symlink_target') do
+    it { should exist }
+    its('content') { should match(/^updated through target$/) }
+  end
+
+  describe file('/tmp/replace_or_add_manage_symlink_source_false') do
+    it { should exist }
+    its('content') { should match(/^updated with explicit false$/) }
+  end
+end


### PR DESCRIPTION
## Summary
- expose `manage_symlink_source` on all file-writing `line` resources
- document the actual Chef 18 symlink-source behavior and add `replace_or_add` integration coverage for explicit `true` and `false` settings
- pass `slack_bot_token` and `slack_channel_id` through the release workflow secrets

## Details
Chef 18.10 does not behave like the current upstream docs suggest for `manage_symlink_source false` on symlink targets. The cookbook docs and tests in this change are aligned to the provider behavior actually shipped in Chef 18.10: explicit `true` manages the symlink source file, while explicit `false` disables that handling and may require unlinking before writing.

Closes #266

## Testing
- `cookstyle`
- `chef exec rspec --format documentation`
- `kitchen test replace-or-add-almalinux-9 --destroy=always`

## Notes
- I did not run the GitHub release workflow locally after adding the Slack secret pass-throughs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/line/287)
<!-- Reviewable:end -->
